### PR TITLE
Support multi-inline environment vars

### DIFF
--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -1040,18 +1040,18 @@ class Systemctl:
                 line = real_line.strip()
                 if not line or line.startswith("#"):
                     continue
-                m = re.match(r"(?:export +)?([\w_]+)[=]'([^']*)'", line)
-                if m:
+                for m in re.finditer(r'"([\w_]+)[=]([^"]*)"', line):
+                    line = line.replace(m.group(0), '')
                     yield m.group(1), m.group(2)
-                    continue
-                m = re.match(r'(?:export +)?([\w_]+)[=]"([^"]*)"', line)
-                if m:
+                for m in re.finditer(r"([\w_]+)[=]'([^']*)'", line):
+                    line = line.replace(m.group(0), '')
                     yield m.group(1), m.group(2)
-                    continue
-                m = re.match(r'(?:export +)?([\w_]+)[=](.*)', line)
-                if m:
+                for m in re.finditer(r'([\w_]+)[=]"([^"]*)"', line):
+                    line = line.replace(m.group(0), '')
                     yield m.group(1), m.group(2)
-                    continue
+                for m in re.finditer(r'([\w_]+)[=](.*)', line):
+                    line = line.replace(m.group(0), '')
+                    yield m.group(1).lstrip(), m.group(2).rstrip()
         except Exception as e:
             logg.info("while reading %s: %s", env_part, e)
     def show_environment(self, unit):

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -1041,16 +1041,16 @@ class Systemctl:
                 if not line or line.startswith("#"):
                     continue
                 for m in re.finditer(r'"([\w_]+)[=]([^"]*)"', line):
-                    line = line.replace(m.group(0), '')
+                    line = line.replace(m.group(0), '', 1)
                     yield m.group(1), m.group(2)
                 for m in re.finditer(r"([\w_]+)[=]'([^']*)'", line):
-                    line = line.replace(m.group(0), '')
+                    line = line.replace(m.group(0), '', 1)
                     yield m.group(1), m.group(2)
                 for m in re.finditer(r'([\w_]+)[=]"([^"]*)"', line):
-                    line = line.replace(m.group(0), '')
+                    line = line.replace(m.group(0), '', 1)
                     yield m.group(1), m.group(2)
                 for m in re.finditer(r'([\w_]+)[=](.*)', line):
-                    line = line.replace(m.group(0), '')
+                    line = line.replace(m.group(0), '', 1)
                     yield m.group(1).lstrip(), m.group(2).rstrip()
         except Exception as e:
             logg.info("while reading %s: %s", env_part, e)

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -1040,18 +1040,18 @@ class Systemctl:
                 line = real_line.strip()
                 if not line or line.startswith("#"):
                     continue
-                m = re.match(r"(?:export +)?([\w_]+)[=]'([^']*)'", line)
-                if m:
+                for m in re.finditer(r'"([\w_]+)[=]([^"]*)"', line):
+                    line = line.replace(m.group(0), '')
                     yield m.group(1), m.group(2)
-                    continue
-                m = re.match(r'(?:export +)?([\w_]+)[=]"([^"]*)"', line)
-                if m:
+                for m in re.finditer(r"([\w_]+)[=]'([^']*)'", line):
+                    line = line.replace(m.group(0), '')
                     yield m.group(1), m.group(2)
-                    continue
-                m = re.match(r'(?:export +)?([\w_]+)[=](.*)', line)
-                if m:
+                for m in re.finditer(r'([\w_]+)[=]"([^"]*)"', line):
+                    line = line.replace(m.group(0), '')
                     yield m.group(1), m.group(2)
-                    continue
+                for m in re.finditer(r'([\w_]+)[=](.*)', line):
+                    line = line.replace(m.group(0), '')
+                    yield m.group(1).lstrip(), m.group(2).rstrip()
         except Exception as e:
             logg.info("while reading %s: %s", env_part, e)
     def show_environment(self, unit):

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -1041,16 +1041,16 @@ class Systemctl:
                 if not line or line.startswith("#"):
                     continue
                 for m in re.finditer(r'"([\w_]+)[=]([^"]*)"', line):
-                    line = line.replace(m.group(0), '')
+                    line = line.replace(m.group(0), '', 1)
                     yield m.group(1), m.group(2)
                 for m in re.finditer(r"([\w_]+)[=]'([^']*)'", line):
-                    line = line.replace(m.group(0), '')
+                    line = line.replace(m.group(0), '', 1)
                     yield m.group(1), m.group(2)
                 for m in re.finditer(r'([\w_]+)[=]"([^"]*)"', line):
-                    line = line.replace(m.group(0), '')
+                    line = line.replace(m.group(0), '', 1)
                     yield m.group(1), m.group(2)
                 for m in re.finditer(r'([\w_]+)[=](.*)', line):
-                    line = line.replace(m.group(0), '')
+                    line = line.replace(m.group(0), '', 1)
                     yield m.group(1).lstrip(), m.group(2).rstrip()
         except Exception as e:
             logg.info("while reading %s: %s", env_part, e)


### PR DESCRIPTION
just an idea, not a python-dev so I am sure can be done better:

```bash
$ cat /lib/systemd/system/exec-environment.service && sudo ./systemctl.py restart exec-environment
[Unit]
Description=Test for Environment

[Service]
ExecStart=/bin/sh -x -c 'echo ".${VAR1}. .${VAR2}. .${VAR3}."'
Type=oneshot
Environment="VAR1=word1 word2" VAR2=word3 "VAR3=$word 5 6"
VAR1 word1 word2 foo
VAR3 $word 5 6 foo
VAR2 word3 foo
VAR1 word1 word2 foo
VAR3 $word 5 6 foo
VAR2 word3 foo
+ echo .word1 word2. .word3. . 5 6.
.word1 word2. .word3. . 5 6.
```

Obviously using regex it is far from perfect - a proper parser might be better here..

This PR will also support `Environment="FOO=bar"` notation, which was initially why I digged into this.

maybe someone can setup travis-ci and use the following test-cases: https://github.com/systemd/systemd/tree/master/test/test-execute ? that way we could achieve a better compat-check with systemd