### PR TITLE
Fix kill of children

### DIFF
--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -20,6 +20,7 @@ import time
 import socket
 import tempfile
 import datetime
+import psutil
 
 if sys.version[0] == '2':
     string_types = basestring
@@ -2074,8 +2075,19 @@ class Systemctl:
         logg.info("done kill PID %s %s", pid, dead and "OK")
         return dead
     def _kill_pid(self, pid, kill_signal = None):
-        try: 
-            sig = kill_signal or signal.SIGTERM
+        sig = kill_signal or signal.SIGTERM
+        # kill all children of the main process
+        try:
+            process = psutil.Process(pid)
+            for child in process.children():
+                try:
+                    os.kill(child.pid, sig)
+                except OSError:
+                    pass
+        except(psutil.NoSuchProcess, psutil.ZombieProcess):
+            pass
+        # kill the main process
+        try:
             os.kill(pid, sig)
         except OSError as e:
             if e.errno == errno.ESRCH or e.errno == errno.ENOENT:


### PR DESCRIPTION
Hi,
I discovered that the `systemctl stop` isn't working with mariadb because the main process didn't stop until all the subprocess ( children ) aren't  stopped too.

For this reason, I have implemented in the `_kill_pid()` method a loop and kill off all children using `psutil`.

In order to make work this fix, we need to install `psutil`:
```bash
# Generic
pip install psutil
# Fedora
dnf install python2-psutil
dnf install python3-psutil
# Centos7 ( with epel-release )
yum install python2-psutil
yum install python34-psutil
```

I'm not sure if this is the best solution but at least I want to share the solution to which I thought.

Bye,
Davide
  