### PR TITLE
Default group should be that of the user

### DIFF
--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -184,6 +184,10 @@ def shutil_setuid(user = None, group = None):
         logg.debug("setgid %s '%s'", gid, group)
     if user:
         import pwd
+        if not group:
+            gid = pwd.getpwnam(user).pw_gid
+            os.setgid(gid)
+            logg.debug("setgid %s", gid)
         uid = pwd.getpwnam(user).pw_uid
         os.setuid(uid)
         logg.debug("setuid %s '%s'", uid, user)

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -183,6 +183,10 @@ def shutil_setuid(user = None, group = None):
         logg.debug("setgid %s '%s'", gid, group)
     if user:
         import pwd
+        if not group:
+            gid = pwd.getpwnam(user).pw_gid
+            os.setgid(gid)
+            logg.debug("setgid %s", gid)
         uid = pwd.getpwnam(user).pw_uid
         os.setuid(uid)
         logg.debug("setuid %s '%s'", uid, user)

--- a/testsuite.py
+++ b/testsuite.py
@@ -10762,6 +10762,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Service]
             Type=simple
             User=user1
+            Group=root
             ExecStart=/usr/bin/testsleep 40
             [Install]
             WantedBy=multi-user.target""")
@@ -10771,7 +10772,6 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Service]
             Type=simple
             User=user1
-            Group=group2
             ExecStart=/usr/bin/testsleep 50
             [Install]
             WantedBy=multi-user.target""")
@@ -10902,6 +10902,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Service]
             Type=simple
             User=user1
+            Group=root
             ExecStart=/usr/bin/testsleep 40
             [Install]
             WantedBy=multi-user.target""")
@@ -10911,7 +10912,6 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Service]
             Type=simple
             User=user1
-            Group=group2
             ExecStart=/usr/bin/testsleep 50
             [Install]
             WantedBy=multi-user.target""")
@@ -11072,6 +11072,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Service]
             Type=simple
             User=user1
+            Group=root
             WorkingDirectory=/srv
             ExecStart=/usr/bin/testsleep.sh 4
             [Install]
@@ -11082,7 +11083,6 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Service]
             Type=simple
             User=user1
-            Group=group2
             WorkingDirectory=/srv
             ExecStart=/usr/bin/testsleep.sh 5
             [Install]


### PR DESCRIPTION
If `User=` is set in a service the group should default to the user's default group, not `root` as at present

https://www.freedesktop.org/software/systemd/man/systemd.exec.html#User=
> If no group is set, the default group of the user is used.