### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ SystemD daemon easily inside a docker container. There have
 been multiple workarounds with varying complexity and actual
 functionality.
 
+Since systemd-nsspawn There are no isssus with systemd running 
+inside a systemd managed Container rkt from CoreOs is using
+systemd-nsspawn in the background to create containers.
+
 Most people have come to take the easy path and to create a
 startup shell script for the docker container that will
 bring up the service processes one by one. Essentially one would


### PR DESCRIPTION
Added Hint to systemd-nsspawn which is a successor over docker/moby libcontainer.
Docker trys to much to be systemd now systemd is docker :+1: