### PR TITLE
Adding ability to include other unit/conf files using .include

### DIFF
--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -384,6 +384,12 @@ class UnitConfigParser:
                 continue
             if line.startswith(";"):
                 continue
+            if line.startswith(".include"):
+                includefile = re.sub(r'^\.include[ ]*', '', line).rstrip()
+                if not os.path.isfile(includefile):
+                    raise Exception("tried to include file that doesn't exist: %s" % includefile)
+                self.read_sysd(includefile)
+                continue
             if line.startswith("["):
                 x = line.find("]")
                 if x > 0:

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -384,6 +384,12 @@ class UnitConfigParser:
                 continue
             if line.startswith(";"):
                 continue
+            if line.startswith(".include"):
+                includefile = re.sub(r'^\.include[ ]*', '', line).rstrip()
+                if not os.path.isfile(includefile):
+                    raise Exception("tried to include file that doesn't exist: %s" % includefile)
+                self.read_sysd(includefile)
+                continue
             if line.startswith("["):
                 x = line.find("]")
                 if x > 0:


### PR DESCRIPTION
This is a systemctl capability that I need. Forgive my crude attempt at solving the problem...it took me a while to find where in the script I needed to add this in. This works for me on CentOS 7.5.

This fixes #54 