### PR TITLE
Use python[23] -m coverage instead of coverage[23]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ checks.3:
 	$(MAKE) checks3_coverage
 	for i in .coverage*; do mv $$i $$i.cov3; done
 checks.4:
-	coverage combine && coverage report && coverage annotate
+	python -m coverage combine && python -m coverage report && python -m coverage annotate
 	ls -l tmp/systemctl.py,cover
 	@ echo ".... are you ready for 'make checkall' ?"
 

--- a/testsuite.py
+++ b/testsuite.py
@@ -89,9 +89,7 @@ def refresh_tool(image):
 def coverage_tool(image = None, python = None):
     image = image or IMAGE
     python = python or _python
-    if python.endswith("3"):
-        return "coverage3"
-    return "coverage2"
+    return python + " -m coverage"
 def coverage_run(image = None, python = None):
     options = " run '--omit=*/six.py,*/extern/*.py,*/unitconfparser.py' --append -- "
     return coverage_tool(image, python) + options


### PR DESCRIPTION
Ubuntu provides the convenience script as python[23]-coverage rather than coverage[23].  But the module form should work everywhere the script would.