### PR TITLE
fail reload if unit not active

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ checks.3:
 	$(MAKE) checks3_coverage
 	for i in .coverage*; do mv $$i $$i.cov3; done
 checks.4:
-	coverage combine && coverage report && coverage annotate
+	python -m coverage combine && python -m coverage report && python -m coverage annotate
 	ls -l tmp/systemctl.py,cover
 	@ echo ".... are you ready for 'make checkall' ?"
 

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -146,12 +146,15 @@ def systemd_normpath(path):
     return re.sub("([^a-zA-Z0-9_/@.\\\\*?!\\[\\]-])", lambda m: "\\x%02x" % ord(m.group(1)), path)
 def systemd_unescape(text):
     try:
-        base_text = bytes(text, sys.getfilesystemencoding()) # python3
+        base_text = bytearray(text, sys.getfilesystemencoding()) # python3
+        hexx_text = base_text.replace(b"-", b"/")
+        core_text = re.sub(b"\\\\x([0-9A-Fa-f]{2})", lambda m: bytes(chr(int(m.group(1), 16)), "utf-8"), hexx_text)
+        return core_text.decode("utf-8")
     except:
-        base_text = unicode(text, sys.getfilesystemencoding()).encode("utf-8")
-    hexx_text = base_text.replace(b"-", b"/")
-    core_text = re.sub(b"\\\\x([0-9A-Fa-f]{2})", lambda m: chr(int(m.group(1), 16)), hexx_text)
-    return core_text.decode("utf-8")
+        base_text = bytearray(text.decode(sys.getfilesystemencoding()), "utf-8")
+        hexx_text = base_text.replace(b"-", b"/")
+        core_text = re.sub(b"\\\\x([0-9A-Fa-f]{2})", lambda m: chr(int(str(m.group(1)), 16)), hexx_text)
+        return core_text.decode("utf-8")
 
 def os_path(root, path):
     if not root:

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -898,7 +898,6 @@ class Systemctl:
                     service_name = systemd_normpath(name)
                     if service_name not in self._file_for_unit_sysd:
                         self._file_for_unit_sysd[service_name] = path
-                        logg.error("storing %s", service_name) # @@
                         unit = parse_unit(service_name)
             logg.debug("found %s sysd files", len(self._file_for_unit_sysd))
         return list(self._file_for_unit_sysd.keys())
@@ -1100,7 +1099,6 @@ class Systemctl:
             else:
                 for module in modules:
                     module_unit = systemd_normpath(module)
-                    logg.error("match on %s", module_unit) #@@
                     if fnmatch.fnmatchcase(item, module_unit):
                         yield item
                     if fnmatch.fnmatchcase(item+suffix, module_unit):

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -2329,6 +2329,10 @@ class Systemctl:
         if self.not_user_conf(conf):
             logg.error("Unit %s not for --user mode", unit)
             return False
+        active = self.get_active_unit(unit)
+        if active != "active":
+            logg.error("Job for %s invalid", unit)
+            return False
         return self.reload_unit_from(conf)
     def reload_unit_from(self, conf):
         if not conf: return False

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -1918,9 +1918,9 @@ class Systemctl:
                         self.set_status_from(conf, "ExecMainCode", run.returncode)
                         active = run.returncode and "failed" or "active"
                         self.write_status_from(conf, AS=active)
-                    if run.returncode:
-                        service_result = "failed"
-                        break
+                if run.returncode and check:
+                    service_result = "failed"
+                    break
         elif runs in [ "notify" ]:
             # "notify" is the same as "simple" but we create a $NOTIFY_SOCKET 
             # and wait for startup completion by checking the socket messages
@@ -1963,9 +1963,9 @@ class Systemctl:
                         self.set_status_from(conf, "ExecMainCode", run.returncode or 0)
                         active = run.returncode and "failed" or "active"
                         self.write_status_from(conf, AS=active)
-                    if run.returncode:
-                        service_result = "failed"
-                        break
+                if run.returncode and check:
+                    service_result = "failed"
+                    break
             if service_result in [ "success" ] and mainpid:
                 logg.debug("okay, wating on socket for %ss", timeout)
                 results = self.wait_notify_socket(notify, timeout, mainpid)

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 __copyright__ = "(C) 2016-2019 Guido U. Draheim, licensed under the EUPL"
-__version__ = "1.4.3244"
+__version__ = "1.4.3245"
 
 import logging
 logg = logging.getLogger("systemctl")

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -144,7 +144,8 @@ def systemd_escape(text):
         base_text = norm_text.encode("utf-8")
     except:
         base_text = norm_text
-    hexx_text = re.sub("([^a-zA-Z_/.])", lambda m: "\\x%02x" % ord(m.group(1)), base_text)
+    # original 'systemd-escape' encodes '@' and '.' when being the first character
+    hexx_text = re.sub("([^a-zA-Z_/@.])", lambda m: "\\x%02x" % ord(m.group(1)), base_text)
     return hexx_text.replace("/","-")
 def systemd_unescape(text):
     try:

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -1076,20 +1076,6 @@ class Systemctl:
         if conf is not None:
             return conf
         return self.default_unit_conf(module)
-    def match_sysd_templates(self, module = None, suffix=".service"): # -> generate[ unit ]
-        """ make a file glob on all known template units (systemd areas).
-            It returns no modules (!!) if no module pattern was given.
-            The module string should contain an instance name already. """
-        if not module:
-            return
-        self.scan_unit_sysd_files()
-        module_unit = parse_unit(systemd_normpath(module))
-        for item in sorted(self._file_for_unit_sysd.keys()):
-            if "@" not in item:
-                continue
-            service_unit = parse_unit(item)
-            if service_unit.prefix == module_unit.prefix:
-                yield "%s@%s.%s" % (service_unit.prefix, module_unit.instance, service_unit.suffix)
     def match_sysd_units(self, module = None, suffix=".service"): # -> generate[ unit ]
         """ make a file glob on all known units (systemd areas).
             It returns all modules if no module pattern was given. """
@@ -1100,6 +1086,12 @@ class Systemctl:
         for item in sorted(self._file_for_unit_sysd.keys()):
             if not module:
                 yield item
+            elif "@." in item:
+                if "@" in module_unit:
+                    item_unit = parse_unit(item)
+                    args_unit = parse_unit(module_unit)
+                    if item_unit.prefix == args_unit.prefix and args_unit.instance:
+                        yield "%s@%s.%s" % (item_unit.prefix, args_unit.instance, item_unit.suffix)
             else:
                 if fnmatch.fnmatchcase(item, module_unit):
                     yield item
@@ -1127,9 +1119,6 @@ class Systemctl:
             Also a single string as one module pattern may be given. """
         found = []
         for unit in self.match_sysd_units(module, suffix):
-            if unit not in found:
-                found.append(unit)
-        for unit in self.match_sysd_templates(module, suffix):
             if unit not in found:
                 found.append(unit)
         for unit in self.match_sysv_units(module, suffix):

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -141,7 +141,7 @@ def unit_of(module):
 def systemd_normpath(path):
     # original 'systemd-escape' encodes '@', and also '.' when being the first character.
     # this one is idempotent when no backslash is ever used in the unescaped unit name.
-    return re.sub("([^a-zA-Z0-9_/@.\\\\])", lambda m: "\\x%02x" % ord(m.group(1)), path)
+    return re.sub("([^a-zA-Z0-9_/@.\\\\-])", lambda m: "\\x%02x" % ord(m.group(1)), path)
 def systemd_escape(text):
     norm_text = re.sub("/+","/", text)
     try:
@@ -1099,9 +1099,10 @@ class Systemctl:
             else:
                 for module in modules:
                     module_unit = systemd_normpath(module)
+                    logg.info("match lookup %s (%s)", module, item)
                     if fnmatch.fnmatchcase(item, module_unit):
                         yield item
-                    if fnmatch.fnmatchcase(item+suffix, module_unit):
+                    if fnmatch.fnmatchcase(item, module_unit+suffix):
                         yield item
     def match_sysv_units(self, modules = None, suffix=".service"): # -> generate[ unit ]
         """ make a file glob on all known units (sysv areas).

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -997,7 +997,8 @@ class Systemctl:
             unit = parse_unit(module)
             service = "%s@.service" % unit.prefix
             conf = self.load_sysd_unit_conf(service)
-            conf.module = module
+            if conf:
+                conf.module = module
             return conf
         return None
     def load_sysd_unit_conf(self, module): # -> conf?

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -27,6 +27,7 @@ else:
     string_types = str
     xrange = range
 
+# --coverage=removelockfile,oldest,spawn,sleep,quick,initializing
 COVERAGE = os.environ.get("SYSTEMCTL_COVERAGE", "")
 DEBUG_AFTER = os.environ.get("SYSTEMCTL_DEBUG_AFTER", "") or False
 EXIT_WHEN_NO_MORE_PROCS = os.environ.get("SYSTEMCTL_EXIT_WHEN_NO_MORE_PROCS", "") or False
@@ -3916,6 +3917,8 @@ class Systemctl:
             the services are stopped again by 'systemctl halt'."""
         default_target = self._default_target
         default_services = self.system_default_services("S", default_target)
+        logg.debug("default services = %s", default_services)
+        if "initializing" in COVERAGE: time.sleep(3)
         self.sysinit_status(SubState = "starting")
         self.start_units(default_services)
         logg.info(" -- system is up")
@@ -4108,6 +4111,7 @@ class Systemctl:
                 logg.info("interrupted - exit init-loop")
                 result = e.message or "STOPPED"
         self.sysinit_status(ActiveState = None, SubState = "degraded")
+        if "initializing" in COVERAGE: time.sleep(3)
         self.read_log_files(units)
         self.read_log_files(units)
         self.stop_log_files(units)

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -1910,6 +1910,7 @@ class Systemctl:
             for cmd in cmdlist:
                 pid = self.read_mainpid_from(conf, "")
                 env["MAINPID"] = str(pid)
+                check, cmd = checkstatus(cmd)
                 newcmd = self.exec_cmd(cmd, env, conf)
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()
@@ -1952,6 +1953,7 @@ class Systemctl:
             for cmd in cmdlist:
                 mainpid = self.read_mainpid_from(conf, "")
                 env["MAINPID"] = str(mainpid)
+                check, cmd = checkstatus(cmd)
                 newcmd = self.exec_cmd(cmd, env, conf)
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -4179,16 +4179,16 @@ class Systemctl:
             state = self.is_system_running()
             if "init" in state:
                 if target in [ "sysinit.target", "basic.target" ]:
-                    logg.info("system not initialized - wait %s", target)
+                    logg.debug("system not initialized - wait %s", target)
                     time.sleep(1)
                     continue
             if "start" in state or "stop" in state:
                 if target in [ "basic.target" ]:
-                    logg.info("system not running - wait %s", target)
+                    logg.debug("system not running - wait %s", target)
                     time.sleep(1)
                     continue
             if "running" not in state:
-                logg.info("system is %s", state)
+                logg.debug("system is %s", state)
             break
     def pidlist_of(self, pid):
         try: pid = int(pid)

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -4112,7 +4112,7 @@ class Systemctl:
                 logg.info("interrupted - exit init-loop")
                 result = e.message or "STOPPED"
         self.sysinit_status(ActiveState = None, SubState = "degraded")
-        if "initializing" in COVERAGE: time.sleep(5)
+        if "initializing" in COVERAGE: time.sleep(3)
         self.read_log_files(units)
         self.read_log_files(units)
         self.stop_log_files(units)

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -144,24 +144,14 @@ def systemd_normpath(path):
     # the fnmatch characters are assumed to not exist in instance objects just as the backslash.
     # this function one is idempotent when no backslash is ever used in the unescaped unit name.
     return re.sub("([^a-zA-Z0-9_/@.\\\\*?!\\[\\]-])", lambda m: "\\x%02x" % ord(m.group(1)), path)
-def systemd_escape(text):
-    # original 'systemd-escape' encodes all '@', and also '.' when being the first character.
-    norm_text = re.sub("/+","/", text)
-    try:
-        base_text = norm_text.encode("utf-8")
-    except:
-        base_text = norm_text
-    hexx_text = re.sub("([^a-zA-Z0-9_/.])", lambda m: "\\x%02x" % ord(m.group(1)), base_text)
-    if hexx_text.startswith("."):
-        hexx_text = "\\x2e"+hexx_text[1:]
-    return hexx_text.replace("/","-")
 def systemd_unescape(text):
     try:
-        base_text = text.decode("utf-8")
+        base_text = bytes(text, sys.getfilesystemencoding()) # python3
     except:
-        base_text = text
-    hexx_text = base_text.replace("-", "/")
-    return re.sub(r"\\x([0-9A-Fa-f]{2})", lambda m: chr(int(m.group(1), 16)), hexx_text)
+        base_text = unicode(text, sys.getfilesystemencoding()).encode("utf-8")
+    hexx_text = base_text.replace(b"-", b"/")
+    core_text = re.sub(b"\\\\x([0-9A-Fa-f]{2})", lambda m: chr(int(m.group(1), 16)), hexx_text)
+    return core_text.decode("utf-8")
 
 def os_path(root, path):
     if not root:

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -4112,7 +4112,7 @@ class Systemctl:
                 logg.info("interrupted - exit init-loop")
                 result = e.message or "STOPPED"
         self.sysinit_status(ActiveState = None, SubState = "degraded")
-        if "initializing" in COVERAGE: time.sleep(3)
+        if "initializing" in COVERAGE: time.sleep(5)
         self.read_log_files(units)
         self.read_log_files(units)
         self.stop_log_files(units)

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -1090,7 +1090,7 @@ class Systemctl:
                 if "@" in module_unit:
                     item_unit = parse_unit(item)
                     args_unit = parse_unit(module_unit)
-                    if item_unit.prefix == args_unit.prefix and args_unit.instance:
+                    if fnmatch.fnmatchcase(item_unit.prefix, args_unit.prefix):
                         yield "%s@%s.%s" % (item_unit.prefix, args_unit.instance, item_unit.suffix)
             else:
                 if fnmatch.fnmatchcase(item, module_unit):

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 __copyright__ = "(C) 2016-2019 Guido U. Draheim, licensed under the EUPL"
-__version__ = "1.4.3207"
+__version__ = "1.4.3244"
 
 import logging
 logg = logging.getLogger("systemctl")

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -1087,7 +1087,7 @@ class Systemctl:
             if not module:
                 yield item
             elif "@." in item:
-                if "@" in module_unit:
+                if "@" in module_unit or "*" in module_unit:
                     item_unit = parse_unit(item)
                     args_unit = parse_unit(module_unit)
                     if fnmatch.fnmatchcase(item_unit.prefix, args_unit.prefix):

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -675,19 +675,19 @@ def time_to_seconds(text, maximum = None):
             return maximum
         if item.endswith("m"):
             try: value += 60 * int(item[:-1])
-            except: pass # pragma: no cover
+            except: pass # pragma: nocover
         if item.endswith("min"):
             try: value += 60 * int(item[:-3])
-            except: pass # pragma: no cover
+            except: pass # pragma: nocover
         elif item.endswith("ms"):
             try: value += int(item[:-2]) / 1000.
-            except: pass # pragma: no cover
+            except: pass # pragma: nocover
         elif item.endswith("s"):
             try: value += int(item[:-1])
-            except: pass # pragma: no cover
+            except: pass # pragma: nocover
         elif item:
             try: value += int(item)
-            except: pass # pragma: no cover
+            except: pass # pragma: nocover
     if value > maximum:
         return maximum
     if not value:
@@ -777,30 +777,30 @@ def sortedAfter(conflist, cmp = compareAfter):
                     itemB = sortlist[B]
                     before = compareAfter(itemA.conf, itemB.conf)
                     if before > 0 and itemA.rank <= itemB.rank:
-                        if DEBUG_AFTER: # pragma: no cover
+                        if DEBUG_AFTER: # pragma: nocover
                             logg.info("  %-30s before %s", itemA.conf.name(), itemB.conf.name())
                         itemA.rank = itemB.rank + 1
                         changed += 1
                     if before < 0 and itemB.rank <= itemA.rank:
-                        if DEBUG_AFTER: # pragma: no cover
+                        if DEBUG_AFTER: # pragma: nocover
                             logg.info("  %-30s before %s", itemB.conf.name(), itemA.conf.name())
                         itemB.rank = itemA.rank + 1
                         changed += 1
         if not changed:
-            if DEBUG_AFTER: # pragma: no cover
+            if DEBUG_AFTER: # pragma: nocover
                 logg.info("done in check %s of %s", check, len(sortlist))
             break
             # because Requires is almost always the same as the After clauses
             # we are mostly done in round 1 as the list is in required order
     for conf in conflist:
-        if DEBUG_AFTER: # pragma: no cover
+        if DEBUG_AFTER: # pragma: nocover
             logg.debug(".. %s", conf.name())
     for item in sortlist:
-        if DEBUG_AFTER: # pragma: no cover
+        if DEBUG_AFTER: # pragma: nocover
             logg.info("(%s) %s", item.rank, item.conf.name())
     sortedlist = sorted(sortlist, key = lambda item: -item.rank)
     for item in sortedlist:
-        if DEBUG_AFTER: # pragma: no cover
+        if DEBUG_AFTER: # pragma: nocover
             logg.info("[%s] %s", item.rank, item.conf.name())
     return [ item.conf for item in sortedlist ]
 
@@ -1859,7 +1859,7 @@ class Systemctl:
                 newcmd = self.exec_cmd(cmd, env, conf)
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()
-                if not forkpid: # pragma: no cover
+                if not forkpid: # pragma: nocover
                     os.setsid() # detach child process from parent
                     self.execve_from(conf, newcmd, env)
                 run = subprocess_waitpid(forkpid)
@@ -1879,7 +1879,7 @@ class Systemctl:
                 newcmd = self.exec_cmd(cmd, env, conf)
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()
-                if not forkpid: # pragma: no cover
+                if not forkpid: # pragma: nocover
                     os.setsid() # detach child process from parent
                     self.execve_from(conf, newcmd, env)
                 run = subprocess_waitpid(forkpid)
@@ -1913,7 +1913,7 @@ class Systemctl:
                 newcmd = self.exec_cmd(cmd, env, conf)
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()
-                if not forkpid: # pragma: no cover
+                if not forkpid: # pragma: nocover
                     os.setsid() # detach child process from parent
                     self.execve_from(conf, newcmd, env)
                 self.write_status_from(conf, MainPID=forkpid)
@@ -1955,7 +1955,7 @@ class Systemctl:
                 newcmd = self.exec_cmd(cmd, env, conf)
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()
-                if not forkpid: # pragma: no cover
+                if not forkpid: # pragma: nocover
                     os.setsid() # detach child process from parent
                     self.execve_from(conf, newcmd, env)
                 # via NOTIFY # self.write_status_from(conf, MainPID=forkpid)
@@ -1998,7 +1998,7 @@ class Systemctl:
                 if not newcmd: continue
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()
-                if not forkpid: # pragma: no cover
+                if not forkpid: # pragma: nocover
                     os.setsid() # detach child process from parent
                     self.execve_from(conf, newcmd, env)
                 logg.info("%s started PID %s", runs, forkpid)
@@ -3652,17 +3652,17 @@ class Systemctl:
         if len(usedExecReload) > 0 and "/bin/kill " in usedExecReload[0]:
             logg.warning(" %s: the use of /bin/kill is not recommended for ExecReload as it is asychronous."
               + "\n\t\t\tThat means all the dependencies will perform the reload simultanously / out of order.", unit)
-        if conf.getlist("Service", "ExecRestart", []): #pragma: no cover
+        if conf.getlist("Service", "ExecRestart", []): #pragma: nocover
             logg.error(" %s: there no such thing as an ExecRestart (ignored)", unit)
-        if conf.getlist("Service", "ExecRestartPre", []): #pragma: no cover
+        if conf.getlist("Service", "ExecRestartPre", []): #pragma: nocover
             logg.error(" %s: there no such thing as an ExecRestartPre (ignored)", unit)
-        if conf.getlist("Service", "ExecRestartPost", []): #pragma: no cover 
+        if conf.getlist("Service", "ExecRestartPost", []): #pragma: nocover 
             logg.error(" %s: there no such thing as an ExecRestartPost (ignored)", unit)
-        if conf.getlist("Service", "ExecReloadPre", []): #pragma: no cover
+        if conf.getlist("Service", "ExecReloadPre", []): #pragma: nocover
             logg.error(" %s: there no such thing as an ExecReloadPre (ignored)", unit)
-        if conf.getlist("Service", "ExecReloadPost", []): #pragma: no cover
+        if conf.getlist("Service", "ExecReloadPost", []): #pragma: nocover
             logg.error(" %s: there no such thing as an ExecReloadPost (ignored)", unit)
-        if conf.getlist("Service", "ExecStopPre", []): #pragma: no cover
+        if conf.getlist("Service", "ExecStopPre", []): #pragma: nocover
             logg.error(" %s: there no such thing as an ExecStopPre (ignored)", unit)
         for env_file in conf.getlist("Service", "EnvironmentFile", []):
             if env_file.startswith("-"): continue
@@ -3674,7 +3674,7 @@ class Systemctl:
         if not conf:
             return True
         if not conf.data.has_section("Service"):
-            return True #pragma: no cover
+            return True #pragma: nocover
         haveType = conf.get("Service", "Type", "simple")
         if haveType in [ "sysv" ]:
             return True # we don't care about that

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -1116,7 +1116,7 @@ class Systemctl:
             else:
                 if fnmatch.fnmatchcase(item, module_unit):
                     yield item
-                if fnmatch.fnmatchcase(item+suffix, module_unit):
+                if fnmatch.fnmatchcase(item, module_unit+suffix):
                     yield item
     def match_units(self, module = None, suffix=".service"): # -> [ units,.. ]
         """ Helper for about any command with multiple units which can

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -2931,7 +2931,9 @@ class Systemctl:
         try:
             unit_file = self.unit_file(unit)
             if unit_file:
-                return open(unit_file).read()
+                text = "# %s\n" % unit_file
+                text += open(unit_file).read()
+                return text
             logg.error("no file for unit '%s'", unit)
         except Exception as e:
             print("Unit {} is not-loaded: {}".format(unit, e))

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -3500,7 +3500,7 @@ class Systemctl:
                     for required in requirelist.strip().split(" "):
                         deps[required.strip()] = style
         return deps
-    def get_start_dependencies(self, unit): # pragma: no cover
+    def get_start_dependencies(self, unit): # pragma: nocover
         """ the list of services to be started as well / TODO: unused """
         deps = {}
         unit_deps = self.get_dependencies_unit(unit)

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -146,12 +146,15 @@ def systemd_normpath(path):
     return re.sub("([^a-zA-Z0-9_/@.\\\\*?!\\[\\]-])", lambda m: "\\x%02x" % ord(m.group(1)), path)
 def systemd_unescape(text):
     try:
-        base_text = bytes(text, sys.getfilesystemencoding()) # python3
+        base_text = bytearray(text, sys.getfilesystemencoding()) # python3
+        hexx_text = base_text.replace(b"-", b"/")
+        core_text = re.sub(b"\\\\x([0-9A-Fa-f]{2})", lambda m: bytes(chr(int(m.group(1), 16)), "utf-8"), hexx_text)
+        return core_text.decode("utf-8")
     except:
-        base_text = unicode(text, sys.getfilesystemencoding()).encode("utf-8")
-    hexx_text = base_text.replace(b"-", b"/")
-    core_text = re.sub(b"\\\\x([0-9A-Fa-f]{2})", lambda m: chr(int(m.group(1), 16)), hexx_text)
-    return core_text.decode("utf-8")
+        base_text = bytearray(text.decode(sys.getfilesystemencoding()), "utf-8")
+        hexx_text = base_text.replace(b"-", b"/")
+        core_text = re.sub(b"\\\\x([0-9A-Fa-f]{2})", lambda m: chr(int(str(m.group(1)), 16)), hexx_text)
+        return core_text.decode("utf-8")
 
 def os_path(root, path):
     if not root:

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -675,19 +675,19 @@ def time_to_seconds(text, maximum = None):
             return maximum
         if item.endswith("m"):
             try: value += 60 * int(item[:-1])
-            except: pass # pragma: no cover
+            except: pass # pragma: nocover
         if item.endswith("min"):
             try: value += 60 * int(item[:-3])
-            except: pass # pragma: no cover
+            except: pass # pragma: nocover
         elif item.endswith("ms"):
             try: value += int(item[:-2]) / 1000.
-            except: pass # pragma: no cover
+            except: pass # pragma: nocover
         elif item.endswith("s"):
             try: value += int(item[:-1])
-            except: pass # pragma: no cover
+            except: pass # pragma: nocover
         elif item:
             try: value += int(item)
-            except: pass # pragma: no cover
+            except: pass # pragma: nocover
     if value > maximum:
         return maximum
     if not value:
@@ -777,30 +777,30 @@ def sortedAfter(conflist, cmp = compareAfter):
                     itemB = sortlist[B]
                     before = compareAfter(itemA.conf, itemB.conf)
                     if before > 0 and itemA.rank <= itemB.rank:
-                        if DEBUG_AFTER: # pragma: no cover
+                        if DEBUG_AFTER: # pragma: nocover
                             logg.info("  %-30s before %s", itemA.conf.name(), itemB.conf.name())
                         itemA.rank = itemB.rank + 1
                         changed += 1
                     if before < 0 and itemB.rank <= itemA.rank:
-                        if DEBUG_AFTER: # pragma: no cover
+                        if DEBUG_AFTER: # pragma: nocover
                             logg.info("  %-30s before %s", itemB.conf.name(), itemA.conf.name())
                         itemB.rank = itemA.rank + 1
                         changed += 1
         if not changed:
-            if DEBUG_AFTER: # pragma: no cover
+            if DEBUG_AFTER: # pragma: nocover
                 logg.info("done in check %s of %s", check, len(sortlist))
             break
             # because Requires is almost always the same as the After clauses
             # we are mostly done in round 1 as the list is in required order
     for conf in conflist:
-        if DEBUG_AFTER: # pragma: no cover
+        if DEBUG_AFTER: # pragma: nocover
             logg.debug(".. %s", conf.name())
     for item in sortlist:
-        if DEBUG_AFTER: # pragma: no cover
+        if DEBUG_AFTER: # pragma: nocover
             logg.info("(%s) %s", item.rank, item.conf.name())
     sortedlist = sorted(sortlist, key = lambda item: -item.rank)
     for item in sortedlist:
-        if DEBUG_AFTER: # pragma: no cover
+        if DEBUG_AFTER: # pragma: nocover
             logg.info("[%s] %s", item.rank, item.conf.name())
     return [ item.conf for item in sortedlist ]
 
@@ -1859,7 +1859,7 @@ class Systemctl:
                 newcmd = self.exec_cmd(cmd, env, conf)
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()
-                if not forkpid: # pragma: no cover
+                if not forkpid: # pragma: nocover
                     os.setsid() # detach child process from parent
                     self.execve_from(conf, newcmd, env)
                 run = subprocess_waitpid(forkpid)
@@ -1879,7 +1879,7 @@ class Systemctl:
                 newcmd = self.exec_cmd(cmd, env, conf)
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()
-                if not forkpid: # pragma: no cover
+                if not forkpid: # pragma: nocover
                     os.setsid() # detach child process from parent
                     self.execve_from(conf, newcmd, env)
                 run = subprocess_waitpid(forkpid)
@@ -1913,7 +1913,7 @@ class Systemctl:
                 newcmd = self.exec_cmd(cmd, env, conf)
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()
-                if not forkpid: # pragma: no cover
+                if not forkpid: # pragma: nocover
                     os.setsid() # detach child process from parent
                     self.execve_from(conf, newcmd, env)
                 self.write_status_from(conf, MainPID=forkpid)
@@ -1955,7 +1955,7 @@ class Systemctl:
                 newcmd = self.exec_cmd(cmd, env, conf)
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()
-                if not forkpid: # pragma: no cover
+                if not forkpid: # pragma: nocover
                     os.setsid() # detach child process from parent
                     self.execve_from(conf, newcmd, env)
                 # via NOTIFY # self.write_status_from(conf, MainPID=forkpid)
@@ -1998,7 +1998,7 @@ class Systemctl:
                 if not newcmd: continue
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()
-                if not forkpid: # pragma: no cover
+                if not forkpid: # pragma: nocover
                     os.setsid() # detach child process from parent
                     self.execve_from(conf, newcmd, env)
                 logg.info("%s started PID %s", runs, forkpid)
@@ -3652,17 +3652,17 @@ class Systemctl:
         if len(usedExecReload) > 0 and "/bin/kill " in usedExecReload[0]:
             logg.warning(" %s: the use of /bin/kill is not recommended for ExecReload as it is asychronous."
               + "\n\t\t\tThat means all the dependencies will perform the reload simultanously / out of order.", unit)
-        if conf.getlist("Service", "ExecRestart", []): #pragma: no cover
+        if conf.getlist("Service", "ExecRestart", []): #pragma: nocover
             logg.error(" %s: there no such thing as an ExecRestart (ignored)", unit)
-        if conf.getlist("Service", "ExecRestartPre", []): #pragma: no cover
+        if conf.getlist("Service", "ExecRestartPre", []): #pragma: nocover
             logg.error(" %s: there no such thing as an ExecRestartPre (ignored)", unit)
-        if conf.getlist("Service", "ExecRestartPost", []): #pragma: no cover 
+        if conf.getlist("Service", "ExecRestartPost", []): #pragma: nocover 
             logg.error(" %s: there no such thing as an ExecRestartPost (ignored)", unit)
-        if conf.getlist("Service", "ExecReloadPre", []): #pragma: no cover
+        if conf.getlist("Service", "ExecReloadPre", []): #pragma: nocover
             logg.error(" %s: there no such thing as an ExecReloadPre (ignored)", unit)
-        if conf.getlist("Service", "ExecReloadPost", []): #pragma: no cover
+        if conf.getlist("Service", "ExecReloadPost", []): #pragma: nocover
             logg.error(" %s: there no such thing as an ExecReloadPost (ignored)", unit)
-        if conf.getlist("Service", "ExecStopPre", []): #pragma: no cover
+        if conf.getlist("Service", "ExecStopPre", []): #pragma: nocover
             logg.error(" %s: there no such thing as an ExecStopPre (ignored)", unit)
         for env_file in conf.getlist("Service", "EnvironmentFile", []):
             if env_file.startswith("-"): continue
@@ -3674,7 +3674,7 @@ class Systemctl:
         if not conf:
             return True
         if not conf.data.has_section("Service"):
-            return True #pragma: no cover
+            return True #pragma: nocover
         haveType = conf.get("Service", "Type", "simple")
         if haveType in [ "sysv" ]:
             return True # we don't care about that
@@ -4112,7 +4112,7 @@ class Systemctl:
                 logg.info("interrupted - exit init-loop")
                 result = e.message or "STOPPED"
         self.sysinit_status(ActiveState = None, SubState = "degraded")
-        if "initializing" in COVERAGE: time.sleep(5)
+        if "initializing" in COVERAGE: time.sleep(3)
         self.read_log_files(units)
         self.read_log_files(units)
         self.stop_log_files(units)

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -898,7 +898,6 @@ class Systemctl:
                     service_name = systemd_normpath(name)
                     if service_name not in self._file_for_unit_sysd:
                         self._file_for_unit_sysd[service_name] = path
-                        logg.error("storing %s", service_name) # @@
                         unit = parse_unit(service_name)
             logg.debug("found %s sysd files", len(self._file_for_unit_sysd))
         return list(self._file_for_unit_sysd.keys())
@@ -1100,7 +1099,6 @@ class Systemctl:
             else:
                 for module in modules:
                     module_unit = systemd_normpath(module)
-                    logg.error("match on %s", module_unit) #@@
                     if fnmatch.fnmatchcase(item, module_unit):
                         yield item
                     if fnmatch.fnmatchcase(item+suffix, module_unit):

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -1918,9 +1918,9 @@ class Systemctl:
                         self.set_status_from(conf, "ExecMainCode", run.returncode)
                         active = run.returncode and "failed" or "active"
                         self.write_status_from(conf, AS=active)
-                    if run.returncode:
-                        service_result = "failed"
-                        break
+                if run.returncode and check:
+                    service_result = "failed"
+                    break
         elif runs in [ "notify" ]:
             # "notify" is the same as "simple" but we create a $NOTIFY_SOCKET 
             # and wait for startup completion by checking the socket messages
@@ -1963,9 +1963,9 @@ class Systemctl:
                         self.set_status_from(conf, "ExecMainCode", run.returncode or 0)
                         active = run.returncode and "failed" or "active"
                         self.write_status_from(conf, AS=active)
-                    if run.returncode:
-                        service_result = "failed"
-                        break
+                if run.returncode and check:
+                    service_result = "failed"
+                    break
             if service_result in [ "success" ] and mainpid:
                 logg.debug("okay, wating on socket for %ss", timeout)
                 results = self.wait_notify_socket(notify, timeout, mainpid)

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 __copyright__ = "(C) 2016-2019 Guido U. Draheim, licensed under the EUPL"
-__version__ = "1.4.3244"
+__version__ = "1.4.3245"
 
 import logging
 logg = logging.getLogger("systemctl")

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -141,7 +141,7 @@ def unit_of(module):
 def systemd_normpath(path):
     # original 'systemd-escape' encodes '@', and also '.' when being the first character.
     # this one is idempotent when no backslash is ever used in the unescaped unit name.
-    return re.sub("([^a-zA-Z0-9_/@.\\\\])", lambda m: "\\x%02x" % ord(m.group(1)), path)
+    return re.sub("([^a-zA-Z0-9_/@.\\\\-])", lambda m: "\\x%02x" % ord(m.group(1)), path)
 def systemd_escape(text):
     norm_text = re.sub("/+","/", text)
     try:
@@ -1069,71 +1069,66 @@ class Systemctl:
         if conf is not None:
             return conf
         return self.default_unit_conf(module)
-    def match_sysd_templates(self, modules = None, suffix=".service"): # -> generate[ unit ]
+    def match_sysd_templates(self, module = None, suffix=".service"): # -> generate[ unit ]
         """ make a file glob on all known template units (systemd areas).
             It returns no modules (!!) if no modules pattern were given.
             The module string should contain an instance name already. """
-        modules = to_list(modules)
-        if not modules:
+        if not module:
             return
         self.scan_unit_sysd_files()
+        module_unit = parse_unit(systemd_normpath(module))
         for item in sorted(self._file_for_unit_sysd.keys()):
             if "@" not in item:
                 continue
             service_unit = parse_unit(item)
-            for module in modules:
-                if "@" not in module:
-                    continue
-                module_unit = parse_unit(systemd_normpath(module))
-                if service_unit.prefix == module_unit.prefix:
-                    yield "%s@%s.%s" % (service_unit.prefix, module_unit.instance, service_unit.suffix)
-    def match_sysd_units(self, modules = None, suffix=".service"): # -> generate[ unit ]
+            if service_unit.prefix == module_unit.prefix:
+                yield "%s@%s.%s" % (service_unit.prefix, module_unit.instance, service_unit.suffix)
+    def match_sysd_units(self, module = None, suffix=".service"): # -> generate[ unit ]
         """ make a file glob on all known units (systemd areas).
             It returns all modules if no modules pattern were given.
             Also a single string as one module pattern may be given. """
-        modules = to_list(modules)
         self.scan_unit_sysd_files()
+        module_unit = systemd_normpath(module)
         for item in sorted(self._file_for_unit_sysd.keys()):
-            if not modules:
+            if not module:
                 yield item
             else:
-                for module in modules:
-                    module_unit = systemd_normpath(module)
-                    if fnmatch.fnmatchcase(item, module_unit):
-                        yield item
-                    if fnmatch.fnmatchcase(item+suffix, module_unit):
-                        yield item
-    def match_sysv_units(self, modules = None, suffix=".service"): # -> generate[ unit ]
+                if fnmatch.fnmatchcase(item, module_unit):
+                    yield item
+                if fnmatch.fnmatchcase(item, module_unit+suffix):
+                    yield item
+    def match_sysv_units(self, module = None, suffix=".service"): # -> generate[ unit ]
         """ make a file glob on all known units (sysv areas).
             It returns all modules if no modules pattern were given.
             Also a single string as one module pattern may be given. """
-        modules = to_list(modules)
         self.scan_unit_sysv_files()
+        module_unit = systemd_normpath(module)
         for item in sorted(self._file_for_unit_sysv.keys()):
-            if not modules:
+            if not module:
                 yield item
             else:
-                for module in modules:
-                    module_unit = systemd_normpath(module)
-                    if fnmatch.fnmatchcase(item, module_unit):
-                        yield item
-                    if fnmatch.fnmatchcase(item+suffix, module_unit):
-                        yield item
+                if fnmatch.fnmatchcase(item, module_unit):
+                    yield item
+                if fnmatch.fnmatchcase(item+suffix, module_unit):
+                    yield item
     def match_units(self, modules = None, suffix=".service"): # -> [ units,.. ]
         """ Helper for about any command with multiple units which can
             actually be glob patterns on their respective unit name. 
             It returns all modules if no modules pattern were given.
             Also a single string as one module pattern may be given. """
         found = []
-        for unit in self.match_sysd_units(modules, suffix):
-            if unit not in found:
-                found.append(unit)
-        for unit in self.match_sysd_templates(modules, suffix):
-            if unit not in found:
-                found.append(unit)
-        for unit in self.match_sysv_units(modules, suffix):
-            if unit not in found:
-                found.append(unit)
+        for module in modules:
+            for unit in self.match_sysd_units(module, suffix):
+                if unit not in found:
+                    found.append(unit)
+        for module in modules:
+            for unit in self.match_sysd_templates(module, suffix):
+                if unit not in found:
+                    found.append(unit)
+        for module in modules:
+            for unit in self.match_sysv_units(module, suffix):
+                if unit not in found:
+                    found.append(unit)
         return found
     def list_service_unit_basics(self):
         """ show all the basic loading state of services """

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -144,7 +144,8 @@ def systemd_escape(text):
         base_text = norm_text.encode("utf-8")
     except:
         base_text = norm_text
-    hexx_text = re.sub("([^a-zA-Z_/.])", lambda m: "\\x%02x" % ord(m.group(1)), base_text)
+    # original 'systemd-escape' encodes '@' and '.' when being the first character
+    hexx_text = re.sub("([^a-zA-Z_/@.])", lambda m: "\\x%02x" % ord(m.group(1)), base_text)
     return hexx_text.replace("/","-")
 def systemd_unescape(text):
     try:

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -1076,20 +1076,6 @@ class Systemctl:
         if conf is not None:
             return conf
         return self.default_unit_conf(module)
-    def match_sysd_templates(self, module = None, suffix=".service"): # -> generate[ unit ]
-        """ make a file glob on all known template units (systemd areas).
-            It returns no modules (!!) if no module pattern was given.
-            The module string should contain an instance name already. """
-        if not module:
-            return
-        self.scan_unit_sysd_files()
-        module_unit = parse_unit(systemd_normpath(module))
-        for item in sorted(self._file_for_unit_sysd.keys()):
-            if "@" not in item:
-                continue
-            service_unit = parse_unit(item)
-            if service_unit.prefix == module_unit.prefix:
-                yield "%s@%s.%s" % (service_unit.prefix, module_unit.instance, service_unit.suffix)
     def match_sysd_units(self, module = None, suffix=".service"): # -> generate[ unit ]
         """ make a file glob on all known units (systemd areas).
             It returns all modules if no module pattern was given. """
@@ -1100,6 +1086,12 @@ class Systemctl:
         for item in sorted(self._file_for_unit_sysd.keys()):
             if not module:
                 yield item
+            elif "@." in item:
+                if "@" in module_unit:
+                    item_unit = parse_unit(item)
+                    args_unit = parse_unit(module_unit)
+                    if item_unit.prefix == args_unit.prefix and args_unit.instance:
+                        yield "%s@%s.%s" % (item_unit.prefix, args_unit.instance, item_unit.suffix)
             else:
                 if fnmatch.fnmatchcase(item, module_unit):
                     yield item
@@ -1127,9 +1119,6 @@ class Systemctl:
             Also a single string as one module pattern may be given. """
         found = []
         for unit in self.match_sysd_units(module, suffix):
-            if unit not in found:
-                found.append(unit)
-        for unit in self.match_sysd_templates(module, suffix):
             if unit not in found:
                 found.append(unit)
         for unit in self.match_sysv_units(module, suffix):

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -997,7 +997,8 @@ class Systemctl:
             unit = parse_unit(module)
             service = "%s@.service" % unit.prefix
             conf = self.load_sysd_unit_conf(service)
-            conf.module = module
+            if conf:
+                conf.module = module
             return conf
         return None
     def load_sysd_unit_conf(self, module): # -> conf?

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -27,6 +27,7 @@ else:
     string_types = str
     xrange = range
 
+# --coverage=removelockfile,oldest,spawn,sleep,quick,initializing
 COVERAGE = os.environ.get("SYSTEMCTL_COVERAGE", "")
 DEBUG_AFTER = os.environ.get("SYSTEMCTL_DEBUG_AFTER", "") or False
 EXIT_WHEN_NO_MORE_PROCS = os.environ.get("SYSTEMCTL_EXIT_WHEN_NO_MORE_PROCS", "") or False
@@ -3916,6 +3917,8 @@ class Systemctl:
             the services are stopped again by 'systemctl halt'."""
         default_target = self._default_target
         default_services = self.system_default_services("S", default_target)
+        logg.debug("default services = %s", default_services)
+        if "initializing" in COVERAGE: time.sleep(3)
         self.sysinit_status(SubState = "starting")
         self.start_units(default_services)
         logg.info(" -- system is up")
@@ -4108,6 +4111,7 @@ class Systemctl:
                 logg.info("interrupted - exit init-loop")
                 result = e.message or "STOPPED"
         self.sysinit_status(ActiveState = None, SubState = "degraded")
+        if "initializing" in COVERAGE: time.sleep(3)
         self.read_log_files(units)
         self.read_log_files(units)
         self.stop_log_files(units)

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -1910,6 +1910,7 @@ class Systemctl:
             for cmd in cmdlist:
                 pid = self.read_mainpid_from(conf, "")
                 env["MAINPID"] = str(pid)
+                check, cmd = checkstatus(cmd)
                 newcmd = self.exec_cmd(cmd, env, conf)
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()
@@ -1952,6 +1953,7 @@ class Systemctl:
             for cmd in cmdlist:
                 mainpid = self.read_mainpid_from(conf, "")
                 env["MAINPID"] = str(mainpid)
+                check, cmd = checkstatus(cmd)
                 newcmd = self.exec_cmd(cmd, env, conf)
                 logg.info("%s start %s", runs, shell_cmd(newcmd))
                 forkpid = os.fork()

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -4179,16 +4179,16 @@ class Systemctl:
             state = self.is_system_running()
             if "init" in state:
                 if target in [ "sysinit.target", "basic.target" ]:
-                    logg.info("system not initialized - wait %s", target)
+                    logg.debug("system not initialized - wait %s", target)
                     time.sleep(1)
                     continue
             if "start" in state or "stop" in state:
                 if target in [ "basic.target" ]:
-                    logg.info("system not running - wait %s", target)
+                    logg.debug("system not running - wait %s", target)
                     time.sleep(1)
                     continue
             if "running" not in state:
-                logg.info("system is %s", state)
+                logg.debug("system is %s", state)
             break
     def pidlist_of(self, pid):
         try: pid = int(pid)

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -144,24 +144,14 @@ def systemd_normpath(path):
     # the fnmatch characters are assumed to not exist in instance objects just as the backslash.
     # this function one is idempotent when no backslash is ever used in the unescaped unit name.
     return re.sub("([^a-zA-Z0-9_/@.\\\\*?!\\[\\]-])", lambda m: "\\x%02x" % ord(m.group(1)), path)
-def systemd_escape(text):
-    # original 'systemd-escape' encodes all '@', and also '.' when being the first character.
-    norm_text = re.sub("/+","/", text)
-    try:
-        base_text = norm_text.encode("utf-8")
-    except:
-        base_text = norm_text
-    hexx_text = re.sub("([^a-zA-Z0-9_/.])", lambda m: "\\x%02x" % ord(m.group(1)), base_text)
-    if hexx_text.startswith("."):
-        hexx_text = "\\x2e"+hexx_text[1:]
-    return hexx_text.replace("/","-")
 def systemd_unescape(text):
     try:
-        base_text = text.decode("utf-8")
+        base_text = bytes(text, sys.getfilesystemencoding()) # python3
     except:
-        base_text = text
-    hexx_text = base_text.replace("-", "/")
-    return re.sub(r"\\x([0-9A-Fa-f]{2})", lambda m: chr(int(m.group(1), 16)), hexx_text)
+        base_text = unicode(text, sys.getfilesystemencoding()).encode("utf-8")
+    hexx_text = base_text.replace(b"-", b"/")
+    core_text = re.sub(b"\\\\x([0-9A-Fa-f]{2})", lambda m: chr(int(m.group(1), 16)), hexx_text)
+    return core_text.decode("utf-8")
 
 def os_path(root, path):
     if not root:

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -4112,7 +4112,7 @@ class Systemctl:
                 logg.info("interrupted - exit init-loop")
                 result = e.message or "STOPPED"
         self.sysinit_status(ActiveState = None, SubState = "degraded")
-        if "initializing" in COVERAGE: time.sleep(3)
+        if "initializing" in COVERAGE: time.sleep(5)
         self.read_log_files(units)
         self.read_log_files(units)
         self.stop_log_files(units)

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -1090,7 +1090,7 @@ class Systemctl:
                 if "@" in module_unit:
                     item_unit = parse_unit(item)
                     args_unit = parse_unit(module_unit)
-                    if item_unit.prefix == args_unit.prefix and args_unit.instance:
+                    if fnmatch.fnmatchcase(item_unit.prefix, args_unit.prefix):
                         yield "%s@%s.%s" % (item_unit.prefix, args_unit.instance, item_unit.suffix)
             else:
                 if fnmatch.fnmatchcase(item, module_unit):

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 
 __copyright__ = "(C) 2016-2019 Guido U. Draheim, licensed under the EUPL"
-__version__ = "1.4.3207"
+__version__ = "1.4.3244"
 
 import logging
 logg = logging.getLogger("systemctl")

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -1087,7 +1087,7 @@ class Systemctl:
             if not module:
                 yield item
             elif "@." in item:
-                if "@" in module_unit:
+                if "@" in module_unit or "*" in module_unit:
                     item_unit = parse_unit(item)
                     args_unit = parse_unit(module_unit)
                     if fnmatch.fnmatchcase(item_unit.prefix, args_unit.prefix):

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -1116,7 +1116,7 @@ class Systemctl:
             else:
                 if fnmatch.fnmatchcase(item, module_unit):
                     yield item
-                if fnmatch.fnmatchcase(item+suffix, module_unit):
+                if fnmatch.fnmatchcase(item, module_unit+suffix):
                     yield item
     def match_units(self, module = None, suffix=".service"): # -> [ units,.. ]
         """ Helper for about any command with multiple units which can

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -2931,7 +2931,9 @@ class Systemctl:
         try:
             unit_file = self.unit_file(unit)
             if unit_file:
-                return open(unit_file).read()
+                text = "# %s\n" % unit_file
+                text += open(unit_file).read()
+                return text
             logg.error("no file for unit '%s'", unit)
         except Exception as e:
             print("Unit {} is not-loaded: {}".format(unit, e))

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -3500,7 +3500,7 @@ class Systemctl:
                     for required in requirelist.strip().split(" "):
                         deps[required.strip()] = style
         return deps
-    def get_start_dependencies(self, unit): # pragma: no cover
+    def get_start_dependencies(self, unit): # pragma: nocover
         """ the list of services to be started as well / TODO: unused """
         deps = {}
         unit_deps = self.get_dependencies_unit(unit)

--- a/testsuite.py
+++ b/testsuite.py
@@ -22993,7 +22993,6 @@ ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELE
         sh____(cmd.format(**locals()))
         #
         self.rm_testdir()
-    @unittest.expectedFailure
     def test_8071_testing_ubuntu_ssh(self):
         """ Checking the issue 71 on Ubuntu on starting ssh"""
         if not os.path.exists(DOCKER_SOCKET): self.skipTest("docker-based test")
@@ -23023,8 +23022,9 @@ ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELE
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} mkdir -p /run/systemd/system"
         sh____(cmd.format(**locals()))
-        cmd = "docker exec {testname} mkdir -p /run/sshd" # <<< WORKAROUND #71
-        sh____(cmd.format(**locals()))
+        if not TODO: # WORKAROUND #71
+            cmd = "docker exec {testname} mkdir -p /run/sshd" 
+            sh____(cmd.format(**locals()))
         ## container = ip_container(testname)
         cmd = "docker exec {testname} touch /var/log/systemctl.debug.log"
         sh____(cmd.format(**locals()))

--- a/testsuite.py
+++ b/testsuite.py
@@ -1531,6 +1531,13 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         out, end = output2(cmd.format(**locals()))
         logg.info(" %s =>%s\n%s", cmd, end, out)
         self.assertEqual(end, 0)
+        cmd = "{systemctl} enable zzz@9.service"
+        out, end = output2(cmd.format(**locals()))
+        logg.info(" %s =>%s\n%s", cmd, end, out)
+        self.assertEqual(end, 0)
+        #
+        self.assertTrue(os.path.exists(os_path(root, "/etc/systemd/system/multi-user.target.wants/zza.service")))
+        self.assertTrue(os.path.exists(os_path(root, "/etc/systemd/system/multi-user.target.wants/zzz@9.service")))
         #
         cmd = "{systemctl} --type=service list-unit-files"
         out, end = output2(cmd.format(**locals()))
@@ -1540,6 +1547,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(out, r"zzb.service\s+enabled"))
         self.assertTrue(greps(out, r"zzc.service\s+enabled"))
         self.assertTrue(greps(out, r"zzd.service\s+enabled"))
+        self.assertTrue(greps(out, r"zzz@.service\s+indirect"))
         if not real: self.assertIn("5 unit files listed.", out)
         if not real: self.assertEqual(len(lines(out)), 8)
         #

--- a/testsuite.py
+++ b/testsuite.py
@@ -3196,8 +3196,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.test_3005_is_enabled_result_when_enabled(True)
     def test_3005_is_enabled_result_when_enabled(self, real = None):
         """ check that 'is-enabled' reports correctly for enabled/disabled """
-        self.begin()
-        vv = "-vv"
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir, real)
@@ -5006,8 +5005,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.test_3050_systemctl_py_check_is_active(True)
     def test_3050_systemctl_py_check_is_active(self, real = None):
         """ check is_active behaviour"""
-        self.begin()
-        vv = "-vv"
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
@@ -5144,8 +5142,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.test_3051_systemctl_py_check_is_failed(True)
     def test_3051_systemctl_py_check_is_failed(self, real = None):
         """ check is_failed behaviour"""
-        self.begin()
-        vv = "-vv"
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
@@ -5297,8 +5294,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.test_3060_is_active_for_forking(True)
     def test_3060_is_active_for_forking(self, real = False):
         """ check that we can start forking services and have them is-active"""
-        self.begin()
-        vv = "-vv"
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
@@ -5388,8 +5384,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.test_3061_is_failed_for_forking(True)
     def test_3061_is_failed_for_forking(self, real = False):
         """ check that we can start forking services and have them is-failed"""
-        self.begin()
-        vv = "-vv"
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
@@ -5480,8 +5475,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ check that we can start forking services and have them is-active,
             even when the pid-file is created later because startup waits
             for its existance."""
-        self.begin()
-        vv = "-vv"
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
@@ -5576,8 +5570,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ consider a situation where a 'systemctl start <service>' is
             taking a bit longer to start. Especially some pre-start
             must be blocking while being in state 'activating'"""
-        self.begin()
-        vv = "-vv"
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
@@ -5715,8 +5708,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ consider a situation where a 'systemctl start <service>' is
             done from two programs at the same time. Ensure that there
             is a locking that disallow then to run in parallel."""
-        self.begin()
-        vv = "-vv"
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
@@ -5829,8 +5821,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             done from two programs at the same time. Ensure that there
             is a locking that disallows them to run in parallel. In this
             scenario we test what happens if the lockfile is deleted in between."""
-        self.begin()
-        vv = "-vv"
+        vv = self.begin()
         removelockfile="--coverage=removelockfile,sleep"
         testname = self.testname()
         testdir = self.testdir()
@@ -5948,11 +5939,10 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.test_3102_mask_service_creates_empty_file(True)
     def test_3102_mask_service_creates_empty_file(self, real = False):
         """ check that a service can be masked """
-        self.begin()
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir, real)
-        vv = "-vv"
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         self.rm_zzfiles(root)
@@ -6022,11 +6012,10 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.test_3104_unmask_service_removes_empty_file(True)
     def test_3104_unmask_service_removes_empty_file(self, real = False):
         """ check that a service can be unmasked """
-        self.begin()
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir, real)
-        vv = "-vv"
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         self.rm_zzfiles(root)
@@ -7508,12 +7497,11 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.test_3609_exitcode_from_ExecReload(True)
     def test_3609_exitcode_from_ExecReload(self, real = False):
         """ check that we get a warning when ExecReload has an error"""
-        self.begin()
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
         root = self.root(testdir, real)
-        vv = "-vv"
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -10536,9 +10524,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ check that we manage a service that has some old .status
             file being around. That is a reboot has occurred and the
             information is not relevant to the current system state."""
-        self.begin()
+        vv = self.begin()
         self.rm_testdir()
-        vv = "-vv"
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
@@ -10642,8 +10629,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ check that we manage a service that has some old .pid
             file being around. That is a reboot has occurred and the
             information is not relevant to the current system state."""
-        self.begin()
-        vv = "-vv"
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
@@ -10755,12 +10741,11 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             with commands like start, restart, stop, etc where
             RemainAfterExit=yes says the service is okay even
             when ExecStart has finished."""
-        self.begin()
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
         root = self.root(testdir, real)
-        vv = "-vv"
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("testsleep")

--- a/testsuite.py
+++ b/testsuite.py
@@ -22716,7 +22716,9 @@ ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELE
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {package} install -y wget procps openssh-server systemd net-tools"
         sh____(cmd.format(**locals()))
-        cmd = "docker exec {testname} mkdir /run/systemd/system"
+        cmd = "docker exec {testname} mkdir -p /run/systemd/system"
+        sh____(cmd.format(**locals()))
+        cmd = "docker exec {testname} mkdir -p /run/sshd" # <<< WORKAROUND #71
         sh____(cmd.format(**locals()))
         ## container = ip_container(testname)
         cmd = "docker exec {testname} touch /var/log/systemctl.debug.log"

--- a/testsuite.py
+++ b/testsuite.py
@@ -185,6 +185,22 @@ def beep():
         # sx___("play -n synth 0.1 tri  1000.0")
         sx____("play -V1 -q -n -c1 synth 0.1 sine 500")
 
+def systemd_escape(text):
+    norm_text = re.sub("/+","/", text)
+    try:
+        base_text = norm_text.encode("utf-8")
+    except:
+        base_text = norm_text
+    hexx_text = re.sub("([^a-zA-Z_/.])", lambda m: "\\x%02x" % ord(m.group(1)), base_text)
+    return hexx_text.replace("/","-")
+def systemd_unescape(text):
+    try:
+        base_text = text.decode("utf-8")
+    except:
+        base_text = text
+    hexx_text = base_text.replace("-", "/")
+    return re.sub(r"\\x([\dA-Fa-f]{2})", lambda m: chr(int(m.group(1), 16)), hexx_text)
+
 def download(base_url, filename, into):
     if not os.path.isdir(into):
         os.makedirs(into)
@@ -6282,7 +6298,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_zzfiles(root)
         print_sh = os_path(root, "/usr/bin/zz_print.sh")
         logfile = os_path(root, "/var/log/zz_print_sh.log")
-        service_file = os_path(root, "/etc/systemd/system/zzb zzc.service")
+        service_name = systemd_escape("zzb zzc.service")
+        service_file = os_path(root, "/etc/systemd/system/" + service_name)
         text_file(service_file,"""
             [Unit]
             Description=Testing B
@@ -6363,7 +6380,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_zzfiles(root)
         print_sh = os_path(root, "/usr/bin/zz_print.sh")
         logfile = os_path(root, "/var/log/zz_print_sh.log")
-        service_file = os_path(root, "/etc/systemd/user/zzb zzc.service")
+        service_name = systemd_escape("zzb zzc.service")
+        service_file = os_path(root, "/etc/systemd/user/"+service_name)
         text_file(service_file,"""
             [Unit]
             Description=Testing B
@@ -6444,7 +6462,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_zzfiles(root)
         print_sh = os_path(root, "/usr/bin/zz_print.sh")
         logfile = os_path(root, "/var/log/zz_print_sh.log")
-        service_file = os_path(root, "/etc/systemd/system/zzb zzc.service")
+        service_name = systemd_escape("zzb zzc.service")
+        service_file = os_path(root, "/etc/systemd/system/"+service_name)
         env_file = "/etc/sysconfig/zz_my.conf"
         extra_vars_file = "/etc/sysconfig/zz_extra.conf"
         env_text_file = os_path(root, env_file)

--- a/testsuite.py
+++ b/testsuite.py
@@ -89,9 +89,9 @@ def refresh_tool(image):
 def coverage_tool(image = None, python = None):
     image = image or IMAGE
     python = python or _python
-    if python.endswith("3"):
-        return "coverage3"
-    return "coverage2"
+    # if python.endswith("3"):
+    #     return "coverage3"
+    return python + " -m coverage"
 def coverage_run(image = None, python = None):
     options = " run '--omit=*/six.py,*/extern/*.py,*/unitconfparser.py' --append -- "
     return coverage_tool(image, python) + options
@@ -20507,9 +20507,9 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker rmi {images}:{testname}"
         sx____(cmd.format(**locals()))
         self.rm_testdir()
-        self.assertGreater(running, 2)
-        self.assertGreater(starting, 2)
-        self.assertGreater(stopping, 2)
+        self.assertGreater(running, 1)
+        self.assertGreater(starting, 1)
+        self.assertGreater(stopping, 1)
         self.assertFalse(other)
         self.assertFalse(others)
     def test_6130_run_default_services_from_simple_saved_container(self):

--- a/testsuite.py
+++ b/testsuite.py
@@ -8215,9 +8215,11 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_zzfiles(root)
         self.coverage()
         self.end()
+    def real_3901_service_config_cat(self):
+        self.test_3901_service_config_cat(real = True)
     def test_3901_service_config_cat(self, real = False):
         """ check that a name service config can be printed as-is"""
-        self.begin()
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
@@ -8241,21 +8243,25 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzs.service"), os_path(root, "/etc/systemd/system/zzs.service"))
         #
-        cmd = "{systemctl} cat zzs.service -vv"
+        cmd = "{systemctl} cat zzs.service {vv}"
         out, end = output2(cmd.format(**locals()))
         logg.info(" %s =>%s \n%s", cmd, end, out)
         self.assertEqual(end, 0)
-        orig = lines(open(os_path(root, "/etc/systemd/system/zzs.service")))
+        unit_file = os_path(root, "/etc/systemd/system/zzs.service")
+        orig = lines("# "+unit_file+"\n"+open(unit_file).read())
         data = lines(out)
-        self.assertEqual(orig + [""], data)
+        if not real: orig += [""]
+        self.assertEqual(orig, data)
         #
         self.rm_testdir()
         self.rm_zzfiles(root)
         self.coverage()
         self.end()
+    def real_3903_service_config_cat_plus_unknown(self):
+        self.test_3903_service_config_cat_plus_unknown(real = True)
     def test_3903_service_config_cat_plus_unknown(self, real = False):
         """ check that a name service config can be printed as-is"""
-        self.begin()
+        vv = self.begin()
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
@@ -8279,13 +8285,15 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzs.service"), os_path(root, "/etc/systemd/system/zzs.service"))
         #
-        cmd = "{systemctl} cat zzs.service unknown.service -vv"
+        cmd = "{systemctl} cat zzs.service unknown.service {vv}"
         out, end = output2(cmd.format(**locals()))
         logg.info(" %s =>%s \n%s", cmd, end, out)
         self.assertEqual(end, 1)
-        orig = lines(open(os_path(root, "/etc/systemd/system/zzs.service")))
+        unit_file = os_path(root, "/etc/systemd/system/zzs.service")
+        orig = lines("# "+unit_file+"\n"+open(unit_file).read())
         data = lines(out)
-        self.assertEqual(orig + [""], data)
+        if not real: orig += [""]
+        self.assertEqual(orig, data)
         #
         self.rm_testdir()
         self.rm_zzfiles(root)

--- a/testsuite.py
+++ b/testsuite.py
@@ -1223,8 +1223,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unknown operation incorrect."))
         self.assertFalse(greps(out, "units listed."))
         self.assertEqual(end, 1)
-        self.rm_zzfiles(root)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def real_1111_default_command(self):
         self.test_1111_default_command(True)
@@ -1243,8 +1243,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(out, "units listed."))
         self.assertTrue(greps(out, "To show all installed unit files use 'systemctl list-unit-files'."))
         self.assertEqual(end, 0)
-        self.rm_zzfiles(root)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def real_1201_get_default(self):
         self.test_1201_get_default(True)
@@ -1262,8 +1262,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         logg.info(" %s =>%s\n%s", cmd, end, out)
         if real: self.assertTrue(greps(out, "graphical.target"))
         else: self.assertTrue(greps(out, "multi-user.target"))
-        self.rm_zzfiles(root)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def real_1211_set_default(self):
         self.test_1211_set_default(True)
@@ -1305,15 +1305,18 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         else: 
             old = "multi-user.target"
             self.assertTrue(greps(out, old))
-        self.rm_zzfiles(root)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
-    def test_2001_can_create_test_services(self):
+    def real_2001_can_create_test_services(self):
+        self.test_2001_can_create_test_services(real = True)
+    def test_2001_can_create_test_services(self, real = False):
         """ check that two unit files can be created for testing """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -1327,6 +1330,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertIn("\nDescription", textA)
         self.assertIn("\nDescription", textB)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2002_list_units(self, real = False):
         """ check that two unit files can be found for 'list-units' """
@@ -1360,6 +1364,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertNotIn("To show all installed unit files use", out)
         self.assertEqual(len(lines(out)), 2)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2003_list_unit_files(self, real = False):
         """ check that two unit service files can be found for 'list-unit-files' """
@@ -1391,6 +1396,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertNotIn("unit files listed.", out)
         self.assertEqual(len(lines(out)), 2)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2004_list_unit_files_wanted(self, real = False):
         """ check that two unit files can be found for 'list-unit-files'
@@ -1425,6 +1431,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertNotIn("unit files listed.", out)
         self.assertEqual(len(lines(out)), 2)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2006_list_unit_files_wanted_and_unknown_type(self, real = False):
         """ check that two unit files can be found for 'list-unit-files'
@@ -1449,6 +1456,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertIn("0 unit files listed.", out)
         self.assertEqual(len(lines(out)), 3)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2008_list_unit_files_locations(self, real = False):
         """ check that unit files can be found for 'list-unit-files'
@@ -1518,6 +1526,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(len(lines(out)), 7)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2010_list_unit_files_locations_user_mode(self, real = False):
         """ check that unit files can be found for 'list-unit-files'
@@ -1597,6 +1606,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(len(lines(out)), 5)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2014_list_unit_files_locations_user_extra(self, real = False):
         """ check that unit files can be found for 'list-unit-files'
@@ -1688,6 +1698,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         #
         logg.info("enabled services for User=%s", user)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2043_list_unit_files_common_targets(self, real = False):
         """ check that some unit target files can be found for 'list-unit-files' """
@@ -1728,6 +1739,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(out, r"multi-user.target\s+enabled"))
         self.assertEqual(len(lines(out)), num_targets + 2)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2044_list_unit_files_now(self, real = False):
         """ check that 'list-unit-files --now' presents a special debug list """
@@ -1752,6 +1764,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertFalse(greps(out, r"enabled"))
         self.assertEqual(len(lines(out)), 2)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2140_show_environment_from_parts(self, real = False):
         """ check that the result of 'environment UNIT' can 
@@ -1791,6 +1804,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         a_lines = len(lines(out))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def real_2147_show_environment_from_some_parts(self):
         self.test_2147_show_environment_from_some_parts(True)
@@ -1915,6 +1929,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         a_lines = len(lines(out))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2220_show_unit_is_parseable(self, real = False):
         """ check that 'show UNIT' is machine-readable """
@@ -1961,6 +1976,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
                 # found non-machine readable property line
                 self.assertEqual("word=value", line)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2221_show_unit_can_be_restricted_to_one_property(self, real = False):
         """ check that 'show UNIT' may return just one value if asked for"""
@@ -2002,6 +2018,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         #
         self.assertEqual(lines(out), [ "PIDFile=" ])
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2225_show_unit_for_multiple_matches(self, real = False):
         """ check that the result of 'show UNIT' for multiple services is 
@@ -2072,6 +2089,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
                 # found non-machine readable property line
                 self.assertEqual("word=value", line)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2227_show_unit_for_oneshot_service(self, real = False):
         """ check that 'show UNIT' is machine-readable """
@@ -2123,6 +2141,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
                 # found non-machine readable property line
                 self.assertEqual("word=value", line)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def test_2230_show_unit_display_parsed_timeouts(self, real = False):
         """ check that 'show UNIT' show parsed timeoutss """
@@ -2225,6 +2244,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertIn("TimeoutStopUSec=3min 2s", rep)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def real_2240_show_environment_from_parts(self):
         self.test_2240_show_environment_from_parts(True)
@@ -2327,7 +2347,6 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.rm_zzfiles(root)
         self.coverage()
-
     def real_2300_override_environment_extras(self):
         self.test_2300_override_environment_extras(True)
     def test_2300_override_environment_extras(self, real = False):
@@ -2882,6 +2901,10 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertIn("ActiveState=inactive", rep)
         self.assertIn("SubState=dead", rep)
         self.assertIn("Id=zz-not-existing.service", rep)
+        #
+        self.rm_testdir()
+        self.rm_zzfiles(root)
+        self.coverage()
         ##
     def test_2612_show_unit_property_not_found(self, real = False):
         """ check when 'show UNIT' not found  """
@@ -2903,6 +2926,9 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(end, 0)
         self.assertEqual(len(out.strip()), 0)
         ##
+        self.rm_testdir()
+        self.rm_zzfiles(root)
+        self.coverage()
     def test_2900_class_UnitConfParser(self):
         """ using systemctl.py as a helper library for 
             the UnitConfParser functions."""
@@ -3013,6 +3039,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(out, "      \\$DEF6 \\$DEF7"))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
     def real_3002_enable_service_creates_a_symlink(self):
         self.test_3002_enable_service_creates_a_symlink(True)
@@ -3048,8 +3075,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         textB = file(enabled_file).read()
         self.assertTrue(greps(textB, "Testing B"))
         self.assertIn("\nDescription", textB)
-        self.rm_zzfiles(root)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def real_3003_disable_service_removes_the_symlink(self):
@@ -3120,8 +3147,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         logg.info(" %s =>%s\n%s", cmd, end, out)
         self.assertNotEqual(end, 0)
         #
-        self.rm_zzfiles(root)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def real_3004_list_unit_files_when_enabled(self):
@@ -3188,8 +3215,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(out, r"zzb.service\s+disabled"))
         self.assertEqual(len(greps(out, "^zz")), 2)
         #
-        self.rm_zzfiles(root)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def real_3005_is_enabled_result_when_enabled(self):
@@ -3255,8 +3282,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(len(lines(out)), 1)
         self.assertEqual(end, 1)
         #
-        self.rm_zzfiles(root)
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3006_is_enabled_is_true_when_any_is_enabled(self, real = False):
@@ -3348,6 +3375,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(len(lines(out)), 2)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3008_is_enabled_for_nonexistant_service(self, real = False):
@@ -3394,6 +3422,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-not-existing-service.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3009_sysv_service_enable(self, real = False):
@@ -3535,6 +3564,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(len(lines(out)), 0)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3010_check_preset_all(self, real = False):
@@ -3612,6 +3642,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(end, 1)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3011_check_preset_one(self, real = False):
@@ -3694,6 +3725,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(end, 1)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3012_check_preset_to_reset_one(self, real = False):
@@ -3818,6 +3850,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(end, 1)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3013_check_preset_to_reset_some(self, real = False):
@@ -3935,6 +3968,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(end, 1)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3015_check_preset_all_only_enable(self, real = False):
@@ -4045,6 +4079,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(end, 0)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3016_check_preset_all_only_disable(self, real = False):
@@ -4155,6 +4190,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(end, 1)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3020_default_services(self, real = False):
@@ -4216,6 +4252,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(out, "c.service"))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3021_default_services(self, real = False):
@@ -4303,6 +4340,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(end, 0)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3025_default_user_services(self, real = False):
@@ -4381,6 +4419,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(out, "d.service"))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3030_systemctl_py_start_simple(self, real = False):
@@ -4440,6 +4479,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3031_systemctl_py_start_extra_simple(self, real = False):
@@ -4498,6 +4538,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3032_systemctl_py_start_forking(self, real = False):
@@ -4575,6 +4616,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3033_systemctl_py_start_forking_without_pid_file(self, real = False):
@@ -4650,6 +4692,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3040_systemctl_py_start_simple_bad_stop(self, real = False):
@@ -4710,6 +4753,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3041_systemctl_py_start_extra_simple_bad_start(self, real = False):
@@ -4768,6 +4812,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3042_systemctl_py_start_forking_bad_stop(self, real = False):
@@ -4846,6 +4891,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3043_systemctl_py_start_forking_bad_start(self, real = False):
@@ -4921,6 +4967,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3049_systemctl_py_run_default_services_in_testenv(self, real = False):
@@ -4999,6 +5046,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def real_3050_systemctl_py_check_is_active(self):
@@ -5288,6 +5336,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def real_3060_is_active_for_forking(self):
@@ -6135,6 +6184,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-not-existing-service.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def real_3201_missing_environment_file_makes_service_ignored(self):
@@ -6182,6 +6232,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def real_3211_environment_files_are_included(self):
@@ -6250,6 +6301,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertFalse(greps(top, testsleep))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def real_3240_may_expand_environment_variables(self):
@@ -6325,6 +6377,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertIn(F, log)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def real_3250_env_may_expand_special_variables(self):
@@ -6407,6 +6460,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             self.assertIn(Z, log)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def real_3255_user_mode_env_may_expand_special_variables(self):
@@ -6491,6 +6545,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             self.assertIn(Z, log)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def real_3260_env_may_expand_special_template_variables(self):
@@ -6573,6 +6628,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             self.assertIn(Z, log)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def real_3270_may_override_environment_from_commandline(self):
@@ -6677,6 +6733,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertIn(T, log)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3301_service_config_show(self, real = False):
@@ -6761,6 +6818,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3302_service_config_show_single_properties(self, real = False):
@@ -6822,6 +6880,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3303_service_config_show_single_properties_plus_unknown(self, real = False):
@@ -6884,6 +6943,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3401_service_status_show(self, real = False):
@@ -6948,6 +7008,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3403_service_status_show_plus_unknown(self, real = False):
@@ -7012,6 +7073,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3530_systemctl_py_default_workingdirectory_is_root(self, real = False):
@@ -7069,6 +7131,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3531_systemctl_py_simple_in_workingdirectory(self, real = False):
@@ -7129,6 +7192,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3532_systemctl_py_with_bad_workingdirectory(self, real = False):
@@ -7190,6 +7254,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3533_systemctl_py_with_bad_workingdirectory(self, real = False):
@@ -7251,6 +7316,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3601_non_absolute_ExecStopPost(self, real = False):
@@ -7291,6 +7357,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3602_non_absolute_ExecStop(self, real = False):
@@ -7331,6 +7398,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3603_non_absolute_ExecReload(self, real = False):
@@ -7374,6 +7442,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3604_non_absolute_ExecStartPost(self, real = False):
@@ -7413,6 +7482,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3605_non_absolute_ExecStartPre(self, real = False):
@@ -7452,6 +7522,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3606_non_absolute_ExecStart(self, real = False):
@@ -7491,6 +7562,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def real_3609_exitcode_from_ExecReload(self):
@@ -7671,6 +7743,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3710_systemctl_py_init_explicit_loop_in_testenv(self, real = False):
@@ -7798,6 +7871,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         kill_testsleep = "killall {testsleep}"
         sx____(kill_testsleep.format(**locals()))
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3801_start_some_unknown(self, real = False):
@@ -7816,6 +7890,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3802_stop_some_unknown(self, real = False):
@@ -7834,6 +7909,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3803_restart_some_unknown(self, real = False):
@@ -7852,6 +7928,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3804_reload_some_unknown(self, real = False):
@@ -7870,6 +7947,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3805_reload_or_restart_some_unknown(self, real = False):
@@ -7888,6 +7966,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3806_reload_or_try_restart_some_unknown(self, real = False):
@@ -7906,6 +7985,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3807_try_restart_some_unknown(self, real = False):
@@ -7924,6 +8004,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3808_kill_some_unknown(self, real = False):
@@ -7942,6 +8023,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3809_reset_failed_some_unknown(self, real = False):
@@ -7960,6 +8042,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3811_mask_some_unknown(self, real = False):
@@ -7978,6 +8061,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3812_unmask_some_unknown(self, real = False):
@@ -7996,6 +8080,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3813_enable_some_unknown(self, real = False):
@@ -8014,6 +8099,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3814_disable_some_unknown(self, real = False):
@@ -8032,6 +8118,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3815_is_enabled_some_unknown(self, real = False):
@@ -8068,6 +8155,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3817_is_active_some_unknown(self, real = False):
@@ -8105,6 +8193,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3819_status_some_unknown(self, real = False):
@@ -8123,9 +8212,9 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(err, "Unit zz-unknown.service could not be found."))
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
-
     def test_3901_service_config_cat(self, real = False):
         """ check that a name service config can be printed as-is"""
         self.begin()
@@ -8161,6 +8250,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(orig + [""], data)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_3903_service_config_cat_plus_unknown(self, real = False):
@@ -8198,6 +8288,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(orig + [""], data)
         #
         self.rm_testdir()
+        self.rm_zzfiles(root)
         self.coverage()
         self.end()
     def test_4030_simple_service_functions_system(self):

--- a/testsuite.py
+++ b/testsuite.py
@@ -1328,12 +1328,13 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertIn("\nDescription", textB)
         self.rm_testdir()
         self.coverage()
-    def test_2002_list_units(self):
+    def test_2002_list_units(self, real = False):
         """ check that two unit files can be found for 'list-units' """
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -1360,12 +1361,13 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(len(lines(out)), 2)
         self.rm_testdir()
         self.coverage()
-    def test_2003_list_unit_files(self):
+    def test_2003_list_unit_files(self, real = False):
         """ check that two unit service files can be found for 'list-unit-files' """
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -1390,13 +1392,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(len(lines(out)), 2)
         self.rm_testdir()
         self.coverage()
-    def test_2004_list_unit_files_wanted(self):
+    def test_2004_list_unit_files_wanted(self, real = False):
         """ check that two unit files can be found for 'list-unit-files'
             with an enabled status """
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -1423,13 +1426,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(len(lines(out)), 2)
         self.rm_testdir()
         self.coverage()
-    def test_2006_list_unit_files_wanted_and_unknown_type(self):
+    def test_2006_list_unit_files_wanted_and_unknown_type(self, real = False):
         """ check that two unit files can be found for 'list-unit-files'
             with an enabled status plus handling unkonwn services"""
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -1446,13 +1450,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(len(lines(out)), 3)
         self.rm_testdir()
         self.coverage()
-    def test_2008_list_unit_files_locations(self):
+    def test_2008_list_unit_files_locations(self, real = False):
         """ check that unit files can be found for 'list-unit-files'
             in different standard locations on disk. """
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A
@@ -1514,13 +1519,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         #
         self.rm_testdir()
         self.coverage()
-    def test_2010_list_unit_files_locations_user_mode(self):
+    def test_2010_list_unit_files_locations_user_mode(self, real = False):
         """ check that unit files can be found for 'list-unit-files'
             in different standard locations on disk for --user mode """
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A
@@ -1592,7 +1598,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         #
         self.rm_testdir()
         self.coverage()
-    def test_2014_list_unit_files_locations_user_extra(self):
+    def test_2014_list_unit_files_locations_user_extra(self, real = False):
         """ check that unit files can be found for 'list-unit-files'
             in different standard locations on disk for --user mode
             with some system files to be pinned on our user. """
@@ -1601,6 +1607,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir)
         user = self.user()
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A
@@ -1682,12 +1689,13 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         logg.info("enabled services for User=%s", user)
         self.rm_testdir()
         self.coverage()
-    def test_2043_list_unit_files_common_targets(self):
+    def test_2043_list_unit_files_common_targets(self, real = False):
         """ check that some unit target files can be found for 'list-unit-files' """
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -1721,12 +1729,13 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(len(lines(out)), num_targets + 2)
         self.rm_testdir()
         self.coverage()
-    def test_2044_list_unit_files_now(self):
+    def test_2044_list_unit_files_now(self, real = False):
         """ check that 'list-unit-files --now' presents a special debug list """
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -1744,13 +1753,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(len(lines(out)), 2)
         self.rm_testdir()
         self.coverage()
-    def test_2140_show_environment_from_parts(self):
+    def test_2140_show_environment_from_parts(self, real = False):
         """ check that the result of 'environment UNIT' can 
             list the settings from different locations."""
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
             DEF1='def1'
             DEF2="def2"
@@ -1868,7 +1878,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.rm_zzfiles(root)
         self.coverage()
-    def test_2150_have_environment_with_multiple_parts(self):
+    def test_2150_have_environment_with_multiple_parts(self, real = False):
         """ check that the result of 'environment UNIT' can 
             list the assignements that are crammed into one line."""
         # https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment=
@@ -1876,6 +1886,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
             DEF1='def1'
             DEF2="def2"
@@ -1905,12 +1916,13 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         #
         self.rm_testdir()
         self.coverage()
-    def test_2220_show_unit_is_parseable(self):
+    def test_2220_show_unit_is_parseable(self, real = False):
         """ check that 'show UNIT' is machine-readable """
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -1950,12 +1962,13 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
                 self.assertEqual("word=value", line)
         self.rm_testdir()
         self.coverage()
-    def test_2221_show_unit_can_be_restricted_to_one_property(self):
+    def test_2221_show_unit_can_be_restricted_to_one_property(self, real = False):
         """ check that 'show UNIT' may return just one value if asked for"""
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -1990,13 +2003,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(lines(out), [ "PIDFile=" ])
         self.rm_testdir()
         self.coverage()
-    def test_2225_show_unit_for_multiple_matches(self):
+    def test_2225_show_unit_for_multiple_matches(self, real = False):
         """ check that the result of 'show UNIT' for multiple services is 
             concatenated but still machine readable. """
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -2059,12 +2073,13 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
                 self.assertEqual("word=value", line)
         self.rm_testdir()
         self.coverage()
-    def test_2227_show_unit_for_oneshot_service(self):
+    def test_2227_show_unit_for_oneshot_service(self, real = False):
         """ check that 'show UNIT' is machine-readable """
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A
@@ -2109,12 +2124,13 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
                 self.assertEqual("word=value", line)
         self.rm_testdir()
         self.coverage()
-    def test_2230_show_unit_display_parsed_timeouts(self):
+    def test_2230_show_unit_display_parsed_timeouts(self, real = False):
         """ check that 'show UNIT' show parsed timeoutss """
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A
@@ -2219,7 +2235,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testdir = self.testdir()
         root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
-        if real: systemctl = "/usr/bin/systemctl"
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
             DEF1='def1'
             DEF2="def2"
@@ -2261,7 +2277,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testdir = self.testdir()
         root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
-        if real: systemctl = "/usr/bin/systemctl"
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
             DEF1='def1'
             DEF2="def2"
@@ -2321,7 +2337,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testdir = self.testdir()
         root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
-        if real: systemctl = "/usr/bin/systemctl"
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
             DEF1='def1'
             DEF2="def2"
@@ -2388,7 +2404,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testdir = self.testdir()
         root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
-        if real: systemctl = "/usr/bin/systemctl"
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
             DEF1='def1'
             DEF2="def2"
@@ -2451,7 +2467,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testdir = self.testdir()
         root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
-        if real: systemctl = "/usr/bin/systemctl"
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
             DEF1='def1'
             DEF2="def2"
@@ -2514,7 +2530,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testdir = self.testdir()
         root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
-        if real: systemctl = "/usr/bin/systemctl"
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
             DEF1='def1'
             DEF2="def2"
@@ -2577,7 +2593,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testdir = self.testdir()
         root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
-        if real: systemctl = "/usr/bin/systemctl"
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
             DEF1='def1'
             DEF2="def2"
@@ -2645,7 +2661,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testdir = self.testdir()
         root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
-        if real: systemctl = "/usr/bin/systemctl"
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
             DEF1='def1'
             DEF2="def2"
@@ -2713,7 +2729,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testdir = self.testdir()
         root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
-        if real: systemctl = "/usr/bin/systemctl"
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
             DEF1='def1'
             DEF2="def2"
@@ -2781,7 +2797,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testdir = self.testdir()
         root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
-        if real: systemctl = "/usr/bin/systemctl"
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
             DEF1='def1'
             DEF2="def2"
@@ -2843,12 +2859,13 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.rm_zzfiles(root)
         self.coverage()
-    def test_2610_show_unit_not_found(self):
+    def test_2610_show_unit_not_found(self, real = False):
         """ check when 'show UNIT' not found  """
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A
@@ -2866,12 +2883,13 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertIn("SubState=dead", rep)
         self.assertIn("Id=zz-not-existing.service", rep)
         ##
-    def test_2612_show_unit_property_not_found(self):
+    def test_2612_show_unit_property_not_found(self, real = False):
         """ check when 'show UNIT' not found  """
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A
@@ -3242,13 +3260,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3006_is_enabled_is_true_when_any_is_enabled(self):
+    def test_3006_is_enabled_is_true_when_any_is_enabled(self, real = False):
         """ check that 'is-enabled' reports correctly for enabled/disabled """
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -3332,13 +3351,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3008_is_enabled_for_nonexistant_service(self):
+    def test_3008_is_enabled_for_nonexistant_service(self, real = False):
         """ check that 'is-enabled' reports correctly for non-existant services """
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zzc.service"),"""
             [Unit]
             Description=Testing C
@@ -3377,7 +3397,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3009_sysv_service_enable(self):
+    def test_3009_sysv_service_enable(self, real = False):
         """ check that we manage SysV services in a root env
             with basic enable/disable commands, also being
             able to check its status."""
@@ -3387,6 +3407,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         logfile = os_path(root, "/var/log/"+testsleep+".log")
         bindir = os_path(root, "/usr/bin")
@@ -3517,13 +3538,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3010_check_preset_all(self):
+    def test_3010_check_preset_all(self, real = False):
         """ check that 'is-enabled' reports correctly after 'preset-all' """
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -3593,13 +3615,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3011_check_preset_one(self):
+    def test_3011_check_preset_one(self, real = False):
         """ check that 'is-enabled' reports correctly after 'preset service' """
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zzb.service"),"""
             [Unit]
             Description=Testing B
@@ -3674,13 +3697,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3012_check_preset_to_reset_one(self):
+    def test_3012_check_preset_to_reset_one(self, real = False):
         """ check that 'enable' and 'preset service' are counterparts """
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zzb.service"),"""
             [Unit]
             Description=Testing B
@@ -3797,13 +3821,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3013_check_preset_to_reset_some(self):
+    def test_3013_check_preset_to_reset_some(self, real = False):
         """ check that 'enable' and 'preset services..' are counterparts """
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zzb.service"),"""
             [Unit]
             Description=Testing B
@@ -3913,13 +3938,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3015_check_preset_all_only_enable(self):
+    def test_3015_check_preset_all_only_enable(self, real = False):
         """ check that 'preset-all' works with --preset-mode=enable """
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -4022,13 +4048,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3016_check_preset_all_only_disable(self):
+    def test_3016_check_preset_all_only_disable(self, real = False):
         """ check that 'preset-all' works with --preset-mode=disable """
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -4131,13 +4158,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3020_default_services(self):
+    def test_3020_default_services(self, real = False):
         """ check the 'default-services' to know the enabled services """
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -4191,13 +4219,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3021_default_services(self):
+    def test_3021_default_services(self, real = False):
         """ check that 'default-services' skips some known services """
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -4277,7 +4306,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3025_default_user_services(self):
+    def test_3025_default_user_services(self, real = False):
         """ check the 'default-services' to know the enabled services """
         self.begin()
         testname = self.testname()
@@ -4285,6 +4314,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir)
         user = self.user()
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A""")
@@ -4354,7 +4384,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3030_systemctl_py_start_simple(self):
+    def test_3030_systemctl_py_start_simple(self, real = False):
         """ check that we can start simple services with root env"""
         self.begin()
         testname = self.testname()
@@ -4362,6 +4392,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzz.service"),"""
@@ -4412,7 +4443,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3031_systemctl_py_start_extra_simple(self):
+    def test_3031_systemctl_py_start_extra_simple(self, real = False):
         """ check that we can start extra simple services with root env"""
         self.begin()
         testname = self.testname()
@@ -4420,6 +4451,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzz.service"),"""
@@ -4469,7 +4501,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3032_systemctl_py_start_forking(self):
+    def test_3032_systemctl_py_start_forking(self, real = False):
         """ check that we can start forking services with root env"""
         self.begin()
         testname = self.testname()
@@ -4477,6 +4509,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         os.makedirs(os_path(root, "/var/run"))
@@ -4545,7 +4578,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3033_systemctl_py_start_forking_without_pid_file(self):
+    def test_3033_systemctl_py_start_forking_without_pid_file(self, real = False):
         """ check that we can start forking services with root env without PIDFile"""
         self.begin()
         testname = self.testname()
@@ -4553,6 +4586,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         os.makedirs(os_path(root, "/var/run"))
@@ -4619,7 +4653,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3040_systemctl_py_start_simple_bad_stop(self):
+    def test_3040_systemctl_py_start_simple_bad_stop(self, real = False):
         """ check that we can start simple services with root env"""
         self.begin()
         testname = self.testname()
@@ -4627,6 +4661,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzz.service"),"""
@@ -4678,7 +4713,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3041_systemctl_py_start_extra_simple_bad_start(self):
+    def test_3041_systemctl_py_start_extra_simple_bad_start(self, real = False):
         """ check that we can start extra simple services with root env"""
         self.begin()
         testname = self.testname()
@@ -4686,6 +4721,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzz.service"),"""
@@ -4735,7 +4771,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3042_systemctl_py_start_forking_bad_stop(self):
+    def test_3042_systemctl_py_start_forking_bad_stop(self, real = False):
         """ check that we can start forking services with root env"""
         self.begin()
         testname = self.testname()
@@ -4743,6 +4779,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         os.makedirs(os_path(root, "/var/run"))
@@ -4812,7 +4849,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3043_systemctl_py_start_forking_bad_start(self):
+    def test_3043_systemctl_py_start_forking_bad_start(self, real = False):
         """ check that we can start forking services with root env without PIDFile"""
         self.begin()
         testname = self.testname()
@@ -4820,6 +4857,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         os.makedirs(os_path(root, "/var/run"))
@@ -4886,7 +4924,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3049_systemctl_py_run_default_services_in_testenv(self):
+    def test_3049_systemctl_py_run_default_services_in_testenv(self, real = False):
         """ check that we can enable services in a test env to be run as default-services"""
         self.begin()
         testname = self.testname()
@@ -4894,6 +4932,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zza.service"),"""
@@ -5256,7 +5295,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.end()
     def real_3060_is_active_for_forking(self):
         self.test_3060_is_active_for_forking(True)
-    def test_3060_is_active_for_forking(self, real = None):
+    def test_3060_is_active_for_forking(self, real = False):
         """ check that we can start forking services and have them is-active"""
         self.begin()
         vv = "-vv"
@@ -5347,7 +5386,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.end()
     def real_3061_is_failed_for_forking(self):
         self.test_3061_is_failed_for_forking(True)
-    def test_3061_is_failed_for_forking(self, real = None):
+    def test_3061_is_failed_for_forking(self, real = False):
         """ check that we can start forking services and have them is-failed"""
         self.begin()
         vv = "-vv"
@@ -5437,7 +5476,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.end()
     def real_3063_is_active_for_forking_delayed(self):
         self.test_3063_is_active_for_forking_delayed(True)
-    def test_3063_is_active_for_forking_delayed(self, real = None):
+    def test_3063_is_active_for_forking_delayed(self, real = False):
         """ check that we can start forking services and have them is-active,
             even when the pid-file is created later because startup waits
             for its existance."""
@@ -5533,7 +5572,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.end()
     def real_3070_check_prestart_is_activating(self):
         self.test_3063_check_prestart_is_activating(True)
-    def test_3070_check_prestart_is_activating(self, real = None):
+    def test_3070_check_prestart_is_activating(self, real = False):
         """ consider a situation where a 'systemctl start <service>' is
             taking a bit longer to start. Especially some pre-start
             must be blocking while being in state 'activating'"""
@@ -5672,7 +5711,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.end()
     def real_3080_two_service_starts_in_parallel(self):
         self.test_3063_two_service_starts_in_parallel(True)
-    def test_3080_two_service_starts_in_parallel(self, real = None):
+    def test_3080_two_service_starts_in_parallel(self, real = False):
         """ consider a situation where a 'systemctl start <service>' is
             done from two programs at the same time. Ensure that there
             is a locking that disallow then to run in parallel."""
@@ -5785,7 +5824,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_zzfiles(root)
         self.coverage()
         self.end()
-    def test_3081_two_service_starts_in_parallel_with_lockfile_remove(self, real = None):
+    def test_3081_two_service_starts_in_parallel_with_lockfile_remove(self, real = False):
         """ consider a situation where a 'systemctl start <service>' is
             done from two programs at the same time. Ensure that there
             is a locking that disallows them to run in parallel. In this
@@ -6063,13 +6102,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3108_is_masked_for_nonexistant_service(self):
+    def test_3108_is_masked_for_nonexistant_service(self, real = False):
         """ check that mask/unmask reports correctly for non-existant services """
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zzc.service"),"""
             [Unit]
             Description=Testing C
@@ -6110,7 +6150,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.end()
     def real_3201_missing_environment_file_makes_service_ignored(self):
         self.test_3201_missing_environment_file_makes_service_ignored(real = True)
-    def test_3201_missing_environment_file_makes_service_ignored(self, real = None):
+    def test_3201_missing_environment_file_makes_service_ignored(self, real = False):
         """ check that a missing EnvironmentFile spec makes the service to be ignored"""
         vv = self.begin()
         testname = self.testname()
@@ -6157,7 +6197,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.end()
     def real_3211_environment_files_are_included(self):
         self.test_3211_environment_files_are_included(real = True)
-    def test_3211_environment_files_are_included(self, real = None):
+    def test_3211_environment_files_are_included(self, real = False):
         """ check that environment specs are read correctly"""
         vv = self.begin()
         testname = self.testname()
@@ -6225,7 +6265,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.end()
     def real_3240_may_expand_environment_variables(self):
         self.test_3240_may_expand_environment_variables(real = True)
-    def test_3240_may_expand_environment_variables(self, real = None):
+    def test_3240_may_expand_environment_variables(self, real = False):
         """ check that different styles of environment
             variables get expanded."""
         vv = self.begin()
@@ -6300,7 +6340,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.end()
     def real_3250_env_may_expand_special_variables(self):
         self.test_3250_env_may_expand_special_variables(real = True)
-    def test_3250_env_may_expand_special_variables(self, real = None):
+    def test_3250_env_may_expand_special_variables(self, real = False):
         """ check that different flavours for special
             variables get expanded."""
         vv = self.begin()
@@ -6383,7 +6423,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
     def real_3255_user_mode_env_may_expand_special_variables(self):
         return True
         ## self.test_3260_user_mode_env_may_expand_special_variables(real = True)
-    def test_3255_user_mode_env_may_expand_special_variables(self, real = None):
+    def test_3255_user_mode_env_may_expand_special_variables(self, real = False):
         """ check that different flavours for special
             variables get expanded. Differently in --user mode."""
         vv = self.begin()
@@ -6466,7 +6506,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.end()
     def real_3260_env_may_expand_special_template_variables(self):
         self.test_3260_env_may_expand_special_template_variables(real = True)
-    def test_3260_env_may_expand_special_template_variables(self, real = None):
+    def test_3260_env_may_expand_special_template_variables(self, real = False):
         """ check that different flavours for special
             variables get expanded. This one uses a template service."""
         vv = self.begin()
@@ -6548,7 +6588,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.end()
     def real_3270_may_override_environment_from_commandline(self):
         self.test_3270_may_override_environment_from_commandline(real = True)
-    def test_3270_may_override_environment_from_commandline(self, real = None):
+    def test_3270_may_override_environment_from_commandline(self, real = False):
         """ check that --extra-vars can be given on the commandline
             to override settings in Environment= and EnvironmentFile=."""
         vv = self.begin()
@@ -6650,7 +6690,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3301_service_config_show(self):
+    def test_3301_service_config_show(self, real = False):
         """ check that a named service config can show its properties"""
         self.begin()
         testname = self.testname()
@@ -6659,6 +6699,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzs.service"),"""
@@ -6733,7 +6774,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3302_service_config_show_single_properties(self):
+    def test_3302_service_config_show_single_properties(self, real = False):
         """ check that a named service config can show a single properties"""
         self.begin()
         testname = self.testname()
@@ -6742,6 +6783,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzs.service"),"""
@@ -6793,7 +6835,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3303_service_config_show_single_properties_plus_unknown(self, real = None):
+    def test_3303_service_config_show_single_properties_plus_unknown(self, real = False):
         """ check that a named service config can show a single properties"""
         self.begin()
         testname = self.testname()
@@ -6855,7 +6897,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3401_service_status_show(self):
+    def test_3401_service_status_show(self, real = False):
         """ check that a named service config can show its status"""
         self.begin()
         testname = self.testname()
@@ -6864,6 +6906,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzs.service"),"""
@@ -6918,7 +6961,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3403_service_status_show_plus_unknown(self):
+    def test_3403_service_status_show_plus_unknown(self, real = False):
         """ check that a named service config can show its status"""
         self.begin()
         testname = self.testname()
@@ -6927,6 +6970,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzs.service"),"""
@@ -6981,7 +7025,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3530_systemctl_py_default_workingdirectory_is_root(self):
+    def test_3530_systemctl_py_default_workingdirectory_is_root(self, real = False):
         """ check that services without WorkingDirectory start in / """
         self.begin()
         testname = self.testname()
@@ -6990,6 +7034,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzz.service"),"""
@@ -7037,7 +7082,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3531_systemctl_py_simple_in_workingdirectory(self):
+    def test_3531_systemctl_py_simple_in_workingdirectory(self, real = False):
         """ check that we can start simple services with a WorkingDirectory"""
         self.begin()
         testname = self.testname()
@@ -7046,6 +7091,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         workingdir = "/var/testsleep"
@@ -7096,7 +7142,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3532_systemctl_py_with_bad_workingdirectory(self):
+    def test_3532_systemctl_py_with_bad_workingdirectory(self, real = False):
         """ check that we can start simple services with a bad WorkingDirectory"""
         self.begin()
         testname = self.testname()
@@ -7105,6 +7151,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         workingdir = "/var/testsleep"
@@ -7156,7 +7203,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3533_systemctl_py_with_bad_workingdirectory(self):
+    def test_3533_systemctl_py_with_bad_workingdirectory(self, real = False):
         """ check that we can start simple services with a bad WorkingDirectory with '-'"""
         self.begin()
         testname = self.testname()
@@ -7165,6 +7212,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         workingdir = "/var/testsleep"
@@ -7216,7 +7264,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3601_non_absolute_ExecStopPost(self):
+    def test_3601_non_absolute_ExecStopPost(self, real = False):
         """ check that we get a strong warning when not using absolute paths in ExecCommands"""
         self.begin()
         testname = self.testname()
@@ -7224,6 +7272,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzz.service"),"""
@@ -7255,7 +7304,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3602_non_absolute_ExecStop(self):
+    def test_3602_non_absolute_ExecStop(self, real = False):
         """ check that we get a strong warning when not using absolute paths in ExecCommands"""
         self.begin()
         testname = self.testname()
@@ -7264,6 +7313,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir)
         quick = "--coverage=quick"
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzz.service"),"""
@@ -7294,7 +7344,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3603_non_absolute_ExecReload(self):
+    def test_3603_non_absolute_ExecReload(self, real = False):
         """ check that we get a strong warning when not using absolute paths in ExecCommands"""
         self.begin()
         testname = self.testname()
@@ -7302,6 +7352,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzz.service"),"""
@@ -7336,7 +7387,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3604_non_absolute_ExecStartPost(self):
+    def test_3604_non_absolute_ExecStartPost(self, real = False):
         """ check that we get a strong warning when not using absolute paths in ExecCommands"""
         self.begin()
         testname = self.testname()
@@ -7344,6 +7395,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzz.service"),"""
@@ -7374,7 +7426,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3605_non_absolute_ExecStartPre(self):
+    def test_3605_non_absolute_ExecStartPre(self, real = False):
         """ check that we get a strong warning when not using absolute paths in ExecCommands"""
         self.begin()
         testname = self.testname()
@@ -7382,6 +7434,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzz.service"),"""
@@ -7412,7 +7465,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3606_non_absolute_ExecStart(self):
+    def test_3606_non_absolute_ExecStart(self, real = False):
         """ check that we get a strong warning when not using absolute paths in ExecCommands"""
         self.begin()
         testname = self.testname()
@@ -7420,6 +7473,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzz.service"),"""
@@ -7503,7 +7557,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_zzfiles(root)
         self.coverage()
         self.end()
-    def test_3700_systemctl_py_default_init_loop_in_testenv(self):
+    def test_3700_systemctl_py_default_init_loop_in_testenv(self, real = False):
         """ check that we can enable services in a test env to be run by an init-loop.
             We expect here that the init-loop ends when all services are dead. """
         self.begin()
@@ -7512,6 +7566,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zza.service"),"""
@@ -7630,7 +7685,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3710_systemctl_py_init_explicit_loop_in_testenv(self):
+    def test_3710_systemctl_py_init_explicit_loop_in_testenv(self, real = False):
         """ check that we can init services in a test env to be run by an init-loop.
             We expect here that the init-loop ends when those services are dead. """
         self.begin()
@@ -7639,6 +7694,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         user = self.user()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zza.service"),"""
@@ -7756,13 +7812,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3801_start_some_unknown(self):
+    def test_3801_start_some_unknown(self, real = False):
         """ check start some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} start zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7773,13 +7830,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3802_stop_some_unknown(self):
+    def test_3802_stop_some_unknown(self, real = False):
         """ check stop some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} stop zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7790,13 +7848,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3803_restart_some_unknown(self):
+    def test_3803_restart_some_unknown(self, real = False):
         """ check restart some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} restart zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7807,13 +7866,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3804_reload_some_unknown(self):
+    def test_3804_reload_some_unknown(self, real = False):
         """ check reload some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} reload zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7824,13 +7884,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3805_reload_or_restart_some_unknown(self):
+    def test_3805_reload_or_restart_some_unknown(self, real = False):
         """ check reload-or-restart some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} reload-or-restart zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7841,13 +7902,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3806_reload_or_try_restart_some_unknown(self):
+    def test_3806_reload_or_try_restart_some_unknown(self, real = False):
         """ check reload-or-try-restart some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} reload-or-try-restart zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7858,13 +7920,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3807_try_restart_some_unknown(self):
+    def test_3807_try_restart_some_unknown(self, real = False):
         """ check try-restart some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} try-restart zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7875,13 +7938,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3808_kill_some_unknown(self):
+    def test_3808_kill_some_unknown(self, real = False):
         """ check kill some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} kill zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7892,13 +7956,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3809_reset_failed_some_unknown(self):
+    def test_3809_reset_failed_some_unknown(self, real = False):
         """ check reset-failed some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} reset-failed zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7909,13 +7974,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3811_mask_some_unknown(self):
+    def test_3811_mask_some_unknown(self, real = False):
         """ check mask some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} mask zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7926,13 +7992,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3812_unmask_some_unknown(self):
+    def test_3812_unmask_some_unknown(self, real = False):
         """ check unmask some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} unmask zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7943,13 +8010,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3813_enable_some_unknown(self):
+    def test_3813_enable_some_unknown(self, real = False):
         """ check enable some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} enable zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7960,13 +8028,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3814_disable_some_unknown(self):
+    def test_3814_disable_some_unknown(self, real = False):
         """ check disable some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} disable zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7977,13 +8046,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3815_is_enabled_some_unknown(self):
+    def test_3815_is_enabled_some_unknown(self, real = False):
         """ check is-enabled some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} is-enabled zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -7994,13 +8064,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3816_is_failed_some_unknown(self):
+    def test_3816_is_failed_some_unknown(self, real = False):
         """ check is-failed some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} is-failed zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -8011,13 +8082,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3817_is_active_some_unknown(self):
+    def test_3817_is_active_some_unknown(self, real = False):
         """ check is-active some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} is-active zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -8028,7 +8100,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3818_get_preset_some_unknown(self):
+    def test_3818_get_preset_some_unknown(self, real = False):
         """ check get-preset some unknown unit fails okay"""
         self.skipTest("get-preset currently not exported")
         self.begin()
@@ -8036,6 +8108,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} get-preset zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -8046,13 +8119,14 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3819_status_some_unknown(self):
+    def test_3819_status_some_unknown(self, real = False):
         """ check get status some unknown unit fails okay"""
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
         root = self.root(testdir)
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
         cmd = "{systemctl} status zz-unknown.service -vv"
         out, err, end = output3(cmd.format(**locals()))
@@ -8064,7 +8138,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.coverage()
         self.end()
 
-    def test_3901_service_config_cat(self):
+    def test_3901_service_config_cat(self, real = False):
         """ check that a name service config can be printed as-is"""
         self.begin()
         testname = self.testname()
@@ -8073,6 +8147,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzs.service"),"""
@@ -8100,7 +8175,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.coverage()
         self.end()
-    def test_3903_service_config_cat_plus_unknown(self):
+    def test_3903_service_config_cat_plus_unknown(self, real = False):
         """ check that a name service config can be printed as-is"""
         self.begin()
         testname = self.testname()
@@ -8109,6 +8184,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
+        if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
         bindir = os_path(root, "/usr/bin")
         text_file(os_path(testdir, "zzs.service"),"""

--- a/testsuite.py
+++ b/testsuite.py
@@ -4,7 +4,7 @@
 from __future__ import print_function
 
 __copyright__ = "(C) Guido Draheim, licensed under the EUPL"""
-__version__ = "1.4.3244"
+__version__ = "1.4.3245"
 
 ## NOTE:
 ## The testcases 1000...4999 are using a --root=subdir environment

--- a/testsuite.py
+++ b/testsuite.py
@@ -4,7 +4,7 @@
 from __future__ import print_function
 
 __copyright__ = "(C) Guido Draheim, licensed under the EUPL"""
-__version__ = "1.4.3207"
+__version__ = "1.4.3244"
 
 ## NOTE:
 ## The testcases 1000...4999 are using a --root=subdir environment

--- a/testsuite.py
+++ b/testsuite.py
@@ -24,6 +24,7 @@ import sys
 from fnmatch import fnmatchcase as fnmatch
 from glob import glob
 import json
+from distutils.spawn import find_executable
 
 logg = logging.getLogger("TESTING")
 _python = "/usr/bin/python"
@@ -45,6 +46,7 @@ SOMETIME = ""
 
 DOCKER_SOCKET = "/var/run/docker.sock"
 PSQL_TOOL = "/usr/bin/psql"
+SLEEP_TOOL = find_executable("sleep")
 
 realpath = os.path.realpath
 
@@ -3413,7 +3415,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             echo "done$1" >&2
             exit 0
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "xxx.init"), os_path(root, "/etc/init.d/xxx"))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/etc/init.d/zzz"))
         #
@@ -4338,7 +4340,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
         cmd = "{systemctl} enable zzz.service"
@@ -4395,7 +4397,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
         cmd = "{systemctl} enable zzz.service"
@@ -4470,7 +4472,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
@@ -4544,7 +4546,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
@@ -4604,7 +4606,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
         cmd = "{systemctl} enable zzz.service"
@@ -4661,7 +4663,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
         cmd = "{systemctl} enable zzz.service"
@@ -4737,7 +4739,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
@@ -4811,7 +4813,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
@@ -4881,7 +4883,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
         copy_file(os_path(testdir, "zzc.service"), os_path(root, "/etc/systemd/system/zzc.service"))
@@ -4962,7 +4964,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
         copy_file(os_path(testdir, "zzc.service"), os_path(root, "/etc/systemd/system/zzc.service"))
@@ -5100,7 +5102,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
         copy_file(os_path(testdir, "zzc.service"), os_path(root, "/etc/systemd/system/zzc.service"))
@@ -5259,7 +5261,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         cmd = "{systemctl} daemon-reload"
@@ -5350,7 +5352,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         sh____("{systemctl} daemon-reload".format(**locals()))
@@ -5443,7 +5445,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         sh____("{systemctl} daemon-reload".format(**locals()))
@@ -5557,9 +5559,9 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep+"pre"))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep+"now"))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep+"pre"))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep+"now"))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
@@ -5696,9 +5698,9 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep+"pre"))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep+"now"))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep+"pre"))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep+"now"))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
@@ -5813,9 +5815,9 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep+"pre"))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep+"now"))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep+"pre"))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep+"now"))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
@@ -6092,7 +6094,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
         start_service = "{systemctl} start zzz.service -vv"
@@ -6150,7 +6152,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             CONF2="bb2"
             CONF3='cc3'
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "zzz.sh"), os_path(bindir, "zzz.sh"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         copy_file(os_path(testdir, "zzz.conf"), os_path(root, "/etc/sysconfig/zzz.conf"))
@@ -6515,7 +6517,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzs.service"), os_path(root, "/etc/systemd/system/zzs.service"))
         #
         cmd = "{systemctl} show zzs.service -vv"
@@ -6598,7 +6600,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzs.service"), os_path(root, "/etc/systemd/system/zzs.service"))
         #
         cmd = "{systemctl} show zzs.service -vv -p ActiveState"
@@ -6658,7 +6660,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzs.service"), os_path(root, "/etc/systemd/system/zzs.service"))
         #
         cmd = "{systemctl} show zzs.service -vv -p ActiveState"
@@ -6718,7 +6720,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzs.service"), os_path(root, "/etc/systemd/system/zzs.service"))
         #
         cmd = "{systemctl} status zzs.service -vv"
@@ -6781,7 +6783,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzs.service"), os_path(root, "/etc/systemd/system/zzs.service"))
         #
         cmd = "{systemctl} status zzs.service other.service -vv"
@@ -6850,7 +6852,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             pwd >> "$log"
             exec {bindir}/{testsleep} 111
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         copy_tool(os_path(testdir, "zzz.sh"), os_path(root, "/usr/bin/zzz.sh"))
         #
@@ -6908,7 +6910,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             pwd >> "$log"
             exec {bindir}/{testsleep} 111
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         copy_tool(os_path(testdir, "zzz.sh"), os_path(root, "/usr/bin/zzz.sh"))
         os.makedirs(os_path(root, workingdir))
@@ -6967,7 +6969,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             pwd >> "$log"
             exec {bindir}/{testsleep} 111
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         copy_tool(os_path(testdir, "zzz.sh"), os_path(root, "/usr/bin/zzz.sh"))
         # os.makedirs(os_path(root, workingdir)) <<<
@@ -7027,7 +7029,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             pwd >> "$log"
             exec {bindir}/{testsleep} 111
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         copy_tool(os_path(testdir, "zzz.sh"), os_path(root, "/usr/bin/zzz.sh"))
         # os.makedirs(os_path(root, workingdir)) <<<
@@ -7078,7 +7080,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
         cmd = "{systemctl} start zzz.service -vv"
@@ -7117,7 +7119,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
         cmd = "{systemctl} start zzz.service -vv"
@@ -7155,7 +7157,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
         cmd = "{systemctl} start zzz.service -vv"
@@ -7197,7 +7199,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
         cmd = "{systemctl} start zzz.service -vv"
@@ -7235,7 +7237,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
         cmd = "{systemctl} start zzz.service -vv"
@@ -7273,7 +7275,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
         cmd = "{systemctl} start zzz.service -vv"
@@ -7315,7 +7317,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         cmd = "{systemctl} start zzz.service {vv}"
         sx____("{systemctl} daemon-reload".format(**locals()))
@@ -7382,7 +7384,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
         copy_file(os_path(testdir, "zzc.service"), os_path(root, "/etc/systemd/system/zzc.service"))
@@ -7509,7 +7511,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
         copy_file(os_path(testdir, "zzc.service"), os_path(root, "/etc/systemd/system/zzc.service"))
@@ -7927,7 +7929,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzs.service"), os_path(root, "/etc/systemd/system/zzs.service"))
         #
         cmd = "{systemctl} cat zzs.service -vv"
@@ -7963,7 +7965,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzs.service"), os_path(root, "/etc/systemd/system/zzs.service"))
         #
         cmd = "{systemctl} cat zzs.service unknown.service -vv"
@@ -8053,7 +8055,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             trap - 3 10 # SIGQUIT SIGUSR1
             date +%T,leave >> {logfile}
         """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
         copy_file(os_path(testdir, "zzz.service"), os_path(root, zzz_service))
         #
@@ -8423,7 +8425,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             WantedBy=multi-user.target
             """.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, zzz_service))
         #
@@ -8754,7 +8756,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             WantedBy=multi-user.target
             """.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, zzz_service))
         #
@@ -9090,7 +9092,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             WantedBy=multi-user.target
             """.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, zzz_service))
         #
@@ -9383,7 +9385,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
            test ! -f "$1" || mv -v "$1" "$2"
         """)
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, zzz_service))
         copy_tool(os_path(testdir, "backup"), os_path(root, "/usr/bin/backup"))
         text_file(os_path(root, "/var/tmp/test.0"), """..""")
@@ -9573,7 +9575,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
            set -x
            test ! -f "$1" || mv -v "$1" "$2"
         """)
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         copy_tool(os_path(testdir, "backup"), os_path(root, "/usr/bin/backup"))
         text_file(os_path(root, "/var/tmp/test.0"), """..""")
@@ -9793,7 +9795,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             echo "done$1" >&2
             exit 0
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/etc/init.d/zzz"))
         #
         cmd = "{systemctl} enable zzz.service -vv"
@@ -10099,7 +10101,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "zzz.init"), os_path(root, "/usr/bin/zzz.init"))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
@@ -10325,7 +10327,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         text_file(os_path(root, "/var/tmp/test.0"), """..""")
         #
@@ -10428,7 +10430,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         #
         cmd = "{systemctl} enable zzz.service -vv"
@@ -10610,7 +10612,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             {bindir}/{testsleep} $1
             exit 2
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "testfail.sh"), os_path(bindir, testfail))
         copy_file(os_path(testdir, "zzz.service"), os_path(root, "/etc/systemd/system/zzz.service"))
         copy_file(os_path(testdir, "zze.service"), os_path(root, "/etc/systemd/system/zze.service"))
@@ -10852,8 +10854,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepB))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepC))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepB))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepC))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
         copy_file(os_path(testdir, "zzc.service"), os_path(root, "/etc/systemd/system/zzc.service"))
         #
@@ -10961,8 +10963,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             [Install]
             WantedBy=multi-user.target
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepB))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepC))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepB))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepC))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
         copy_file(os_path(testdir, "zzc.service"), os_path(root, "/etc/systemd/system/zzc.service"))
         os.makedirs(rundir)
@@ -11143,8 +11145,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             trap - 3 10 15 # SIGQUIT SIGUSR1 SIGTERM
             date +%T,leave >> {logfile}
         """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepB))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepC))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepB))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepC))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
         #
         cmd = "{systemctl} start zzb.service -vv"
@@ -11261,8 +11263,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             trap - 3 10 15 # SIGQUIT SIGUSR1 SIGTERM
             date +%T,leave >> {logfile}
         """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepB))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepC))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepB))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepC))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
         #
         cmd = "{systemctl} start zzb.service -vv"
@@ -11381,8 +11383,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             trap - 3 10 15  # SIGQUIT SIGUSR1 SIGTERM
             date +%T,leave >> {logfile}
         """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepB))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepC))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepB))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepC))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
         #
         cmd = "{systemctl} start zzb.service -vv"
@@ -11501,8 +11503,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             trap - 3 10 15  # SIGQUIT SIGUSR1 SIGTERM
             date +%T,leave >> {logfile}
         """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepB))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepC))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepB))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepC))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
         #
         cmd = "{systemctl} start zzb.service -vv"
@@ -11621,8 +11623,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             trap - 3 10 15  # SIGQUIT SIGUSR1 SIGTERM
             date +%T,leave >> {logfile}
         """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepB))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleepC))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepB))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleepC))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
         #
         cmd = "{systemctl} start zzb.service -vv"
@@ -11722,7 +11724,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             cat {logfile} | sed -e "s|^| : |"
             true
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "logger"), os_path(bindir, "logger"))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
@@ -11824,7 +11826,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             cat {logfile} | sed -e "s|^| : |"
             true
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "logger"), os_path(bindir, "logger"))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
@@ -11926,7 +11928,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             cat {logfile} | sed -e "s|^| : |"
             true
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "logger"), os_path(bindir, "logger"))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
@@ -12029,7 +12031,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             cat {logfile} | sed -e "s|^| : |"
             true
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "logger"), os_path(bindir, "logger"))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
@@ -12105,7 +12107,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             cat {logfile} | sed -e "s|^| : |"
             true
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "logger"), os_path(bindir, "logger"))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
@@ -12204,7 +12206,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             cat {logfile} | sed -e "s|^| : |"
             true
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "logger"), os_path(bindir, "logger"))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
@@ -12303,7 +12305,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             cat {logfile} | sed -e "s|^| : |"
             true
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "logger"), os_path(bindir, "logger"))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
@@ -12379,7 +12381,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             cat {logfile} | sed -e "s|^| : |"
             true
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "logger"), os_path(bindir, "logger"))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
@@ -12479,7 +12481,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             cat {logfile} | sed -e "s|^| : |"
             true
             """.format(**locals()))
-        copy_tool("/usr/bin/sleep", os_path(bindir, testsleep))
+        copy_tool(SLEEP_TOOL, os_path(bindir, testsleep))
         copy_tool(os_path(testdir, "logger"), os_path(bindir, "logger"))
         copy_file(os_path(testdir, "zza.service"), os_path(root, "/etc/systemd/system/zza.service"))
         copy_file(os_path(testdir, "zzb.service"), os_path(root, "/etc/systemd/system/zzb.service"))
@@ -13073,7 +13075,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
              cmd = "docker exec {testname} {package} install -y {python_coverage}"
              sx____(cmd.format(**locals()))
         self.prep_coverage(testname)
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/{testscript} {testname}:{bindir}/{testscript}"
         sh____(cmd.format(**locals()))
@@ -13491,7 +13493,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -13862,7 +13864,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -14247,7 +14249,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -14589,7 +14591,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.service {testname}:{zzz_service}"
         sh____(cmd.format(**locals()))
@@ -14853,7 +14855,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.service {testname}:/etc/systemd/system/zzz.service"
         sh____(cmd.format(**locals()))
@@ -15144,7 +15146,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
              cmd = "docker exec {testname} {package} install -y {python_coverage}"
              sx____(cmd.format(**locals()))
         self.prep_coverage(testname)
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/etc/init.d/zzz"
         sh____(cmd.format(**locals()))
@@ -15469,7 +15471,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
         cmd = "docker cp {testdir}/zzz.service {testname}:{zzz_service}"
@@ -15669,7 +15671,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
              cmd = "docker exec {testname} {package} install -y {python_coverage}"
              sx____(cmd.format(**locals()))
         self.prep_coverage(testname)
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/{testscript} {testname}:{bindir}/{testscript}"
         sh____(cmd.format(**locals()))
@@ -16104,7 +16106,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -16492,7 +16494,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -16893,7 +16895,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -17251,7 +17253,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.service {testname}:{zzz_service}"
         sh____(cmd.format(**locals()))
@@ -17532,7 +17534,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.service {testname}:/etc/systemd/system/zzz.service"
         sh____(cmd.format(**locals()))
@@ -17840,7 +17842,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
              cmd = "docker exec {testname} {package} install -y {python_coverage}"
              sx____(cmd.format(**locals()))
         self.prep_coverage(testname)
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/etc/init.d/zzz"
         sh____(cmd.format(**locals()))
@@ -17987,7 +17989,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
              cmd = "docker exec {testname} {package} install -y {python_coverage}"
              sx____(cmd.format(**locals()))
         self.prep_coverage(testname)
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/{testscript} {testname}:{bindir}/{testscript}"
         sh____(cmd.format(**locals()))
@@ -18201,7 +18203,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/system/zzz.service".format(**locals())
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -18424,7 +18426,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/system/zzz.service".format(**locals())
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -18651,7 +18653,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/system/zzz.service".format(**locals())
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -18835,7 +18837,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/system/zzz.service".format(**locals())
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.service {testname}:{zzz_service}"
         sh____(cmd.format(**locals()))
@@ -19012,7 +19014,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/system/zzz.service".format(**locals())
-        cmd = "docker cp /usr/bin/sleep {testname}:{bindir}/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.service {testname}:{zzz_service}"
         sh____(cmd.format(**locals()))
@@ -19143,7 +19145,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/killall {testname}:/usr/bin/killall"
         sh____(cmd.format(**locals()))
@@ -19217,7 +19219,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
              cmd = "docker exec {testname} {package} install -y {python_coverage}"
              sx____(cmd.format(**locals()))
         self.prep_coverage(testname)
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
@@ -19315,7 +19317,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/killall {testname}:/usr/bin/killall"
         sh____(cmd.format(**locals()))
@@ -19412,7 +19414,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/killall {testname}:/usr/bin/killall"
         sh____(cmd.format(**locals()))
@@ -19497,7 +19499,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/killall {testname}:/usr/bin/killall"
         sh____(cmd.format(**locals()))
@@ -19582,7 +19584,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zza.service {testname}:/etc/systemd/system/zza.service"
         sh____(cmd.format(**locals()))
@@ -19680,7 +19682,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zza.service {testname}:/etc/systemd/system/zza.service"
         sh____(cmd.format(**locals()))
@@ -19801,7 +19803,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zza.service {testname}:/etc/systemd/system/zza.service"
         sh____(cmd.format(**locals()))
@@ -19906,7 +19908,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zza.service {testname}:/etc/systemd/system/zza.service"
         sh____(cmd.format(**locals()))
@@ -20012,7 +20014,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zza.service {testname}:/etc/systemd/system/zza.service"
         sh____(cmd.format(**locals()))
@@ -20124,7 +20126,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -20231,7 +20233,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -20335,7 +20337,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -20477,7 +20479,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -20624,7 +20626,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -20761,7 +20763,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -20911,7 +20913,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -21034,7 +21036,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -21190,7 +21192,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/testsleep"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testsleep_sh} {testname}:/usr/bin/testsleep.sh"
         sh____(cmd.format(**locals()))
@@ -21309,7 +21311,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker cp /usr/bin/sleep {testname}:/usr/bin/{testsleep}"
+        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/{testsleep}"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} touch /var/log/systemctl.debug.log"
         sh____(cmd.format(**locals()))

--- a/testsuite.py
+++ b/testsuite.py
@@ -1336,7 +1336,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ check that two unit files can be found for 'list-units' """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -1370,7 +1370,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ check that two unit service files can be found for 'list-unit-files' """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -1403,7 +1403,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             with an enabled status """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -1438,7 +1438,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             with an enabled status plus handling unkonwn services"""
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -1463,7 +1463,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             in different standard locations on disk. """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -1533,7 +1533,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             in different standard locations on disk for --user mode """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -1614,7 +1614,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             with some system files to be pinned on our user. """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         user = self.user()
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
@@ -1704,7 +1704,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ check that some unit target files can be found for 'list-unit-files' """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -1745,7 +1745,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ check that 'list-unit-files --now' presents a special debug list """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -1771,7 +1771,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             list the settings from different locations."""
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
@@ -1898,7 +1898,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         # https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment=
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/sysconfig/zzb.conf"),"""
@@ -1935,7 +1935,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ check that 'show UNIT' is machine-readable """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -1982,7 +1982,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ check that 'show UNIT' may return just one value if asked for"""
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -2025,7 +2025,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             concatenated but still machine readable. """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -2095,7 +2095,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ check that 'show UNIT' is machine-readable """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -2147,7 +2147,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ check that 'show UNIT' show parsed timeoutss """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -2882,7 +2882,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ check when 'show UNIT' not found  """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -2910,7 +2910,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         """ check when 'show UNIT' not found  """
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -3291,7 +3291,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -3383,7 +3383,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zzc.service"),"""
@@ -3433,7 +3433,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -3572,7 +3572,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -3650,7 +3650,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zzb.service"),"""
@@ -3733,7 +3733,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zzb.service"),"""
@@ -3858,7 +3858,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zzb.service"),"""
@@ -3976,7 +3976,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -4087,7 +4087,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -4198,7 +4198,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -4260,7 +4260,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
@@ -4348,7 +4348,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         user = self.user()
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
@@ -4428,7 +4428,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -4488,7 +4488,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -4547,7 +4547,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -4625,7 +4625,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -4701,7 +4701,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -4762,7 +4762,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -4821,7 +4821,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -4900,7 +4900,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -4976,7 +4976,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -6145,7 +6145,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         text_file(os_path(root, "/etc/systemd/system/zzc.service"),"""
@@ -6742,7 +6742,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
@@ -6827,7 +6827,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
@@ -6952,7 +6952,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
@@ -7017,7 +7017,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
@@ -7082,7 +7082,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
@@ -7140,7 +7140,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
@@ -7201,7 +7201,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
@@ -7263,7 +7263,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
@@ -7325,7 +7325,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -7366,7 +7366,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         quick = "--coverage=quick"
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
@@ -7407,7 +7407,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -7451,7 +7451,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -7491,7 +7491,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -7531,7 +7531,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -7624,7 +7624,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -7753,7 +7753,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         testsleep = self.testname("sleep")
@@ -7879,7 +7879,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -7898,7 +7898,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -7917,7 +7917,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -7936,7 +7936,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -7955,7 +7955,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -7974,7 +7974,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -7993,7 +7993,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -8012,7 +8012,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -8031,7 +8031,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -8050,7 +8050,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -8069,7 +8069,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -8088,7 +8088,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -8107,7 +8107,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -8126,7 +8126,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -8144,7 +8144,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -8163,7 +8163,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -8182,7 +8182,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -8201,7 +8201,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.begin()
         testname = self.testname()
         testdir = self.testdir()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
         #
@@ -8221,7 +8221,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
@@ -8259,7 +8259,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         testname = self.testname()
         testdir = self.testdir()
         user = self.user()
-        root = self.root(testdir)
+        root = self.root(testdir, real)
         logfile = os_path(root, "/var/log/test.log")
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"

--- a/testsuite.py
+++ b/testsuite.py
@@ -20400,6 +20400,118 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         self.rm_testdir()
 
+    def test_5800_systemctl_py_is_system_running(self):
+        """ check that the startup and shutdown sequence with the sysvinit.status target"""
+        if not os.path.exists(DOCKER_SOCKET): self.skipTest("docker-based test")
+        images = IMAGES
+        image = self.local_image(COVERAGE or IMAGE or CENTOS)
+        if _python.endswith("python3") and "centos" in image: 
+            self.skipTest("no python3 on centos")
+        testname = self.testname()
+        testdir = self.testdir()
+        package = package_tool(image)
+        refresh = refresh_tool(image)
+        python = os.path.basename(_python)
+        python_coverage = coverage_package(image)
+        systemctl_py = _systemctl_py
+        sometime = SOMETIME or 188
+        FROM=200
+        UPTO=222
+        for xxx in xrange(FROM, UPTO):
+            text_file(os_path(testdir, "zz%i.service" %xxx),"""
+                [Unit]
+                Description=Testing %i
+                [Service]
+                Type=simple
+                ExecStart=/usr/bin/testsleep 99
+                [Install]
+                WantedBy=multi-user.target""" %xxx)
+        #
+        cmd = "docker rm --force {testname}"
+        sx____(cmd.format(**locals()))
+        cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
+        sh____(cmd.format(**locals()))
+        cmd = "docker exec {testname} {refresh}"
+        sh____(cmd.format(**locals()))
+        cmd = "docker exec {testname} bash -c 'ls -l /usr/bin/{python} || {package} install -y {python}'"
+        sx____(cmd.format(**locals()))
+        if COVERAGE:
+             cmd = "docker exec {testname} {package} install -y {python_coverage}"
+             sx____(cmd.format(**locals()))
+        self.prep_coverage(testname)
+        cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
+        sx____(cmd.format(**locals()))
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
+        sh____(cmd.format(**locals()))
+        for xxx in xrange(FROM, UPTO):
+            cmd = "docker cp {testdir}/zz{xxx}.service {testname}:/etc/systemd/system/"
+            sh____(cmd.format(**locals()))
+            cmd = "docker exec {testname} systemctl enable zz{xxx}.service"
+            sh____(cmd.format(**locals()))
+        cmd = "docker exec {testname} systemctl --version"
+        sh____(cmd.format(**locals()))
+        cmd = "docker exec {testname} systemctl default-services -v"
+        # sh____(cmd.format(**locals()))
+        out2 = output(cmd.format(**locals()))
+        logg.info("\n>\n%s", out2)
+        # .........................................vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+        cmd = "docker commit -c 'CMD [\"/usr/bin/systemctl\"]'  {testname} {images}:{testname}"
+        sh____(cmd.format(**locals()))
+        cmd = "docker rm --force {testname}x"
+        sx____(cmd.format(**locals()))
+        logg.info("=========================================================================")
+        time.sleep(2)
+        logg.info("=========================================================================")
+        cmd = "docker run --detach --name {testname}x {images}:{testname}"
+        sh____(cmd.format(**locals()))
+        starting = 0
+        running = 0
+        other = 0
+        for xx in xrange(10,50):
+            cmd = "docker exec {testname}x systemctl is-system-running"
+            chk = output(cmd.format(**locals()))
+            logg.info("\n>>>\n%s", chk)
+            if chk.strip() in "starting": starting += 1
+            elif chk.strip() in "running": running += 1
+            else: other += 1
+            top_container2 = "docker exec {testname}x ps -eo pid,ppid,user,args"
+            top = output(top_container2.format(**locals()))
+            logg.info("\n>>>\n%s", top)
+            time.sleep(2)
+            if running > 3: break
+        logg.info("-------------------------------------------------------------------------")
+        time.sleep(2)
+        logg.info("-------------------------------------------------------------------------")
+        cmd = "docker exec {testname}x systemctl halt"
+        sh____(cmd.format(**locals()))
+        stopping = 0
+        others = 0
+        for xx in xrange(10,50):
+            cmd = "docker exec {testname}x systemctl is-system-running"
+            chk = output(cmd.format(**locals()))
+            logg.info("\n>>>\n%s", chk)
+            if not chk.strip(): break
+            if chk.strip() in "stopping": stopping += 1
+            else: others += 1
+            top_container2 = "docker exec {testname}x ps -eo pid,ppid,user,args"
+            top = output(top_container2.format(**locals()))
+            logg.info("\n>>>\n%s", top)
+            time.sleep(2)
+        #
+        self.save_coverage(testname, testname+"x")
+        #
+        cmd = "docker rm --force {testname}"
+        sx____(cmd.format(**locals()))
+        cmd = "docker rm --force {testname}x"
+        sx____(cmd.format(**locals()))
+        cmd = "docker rmi {images}:{testname}"
+        sx____(cmd.format(**locals()))
+        self.rm_testdir()
+        self.assertGreater(running, 2)
+        self.assertGreater(starting, 2)
+        self.assertGreater(stopping, 2)
+        self.assertFalse(other)
+        self.assertFalse(others)
     def test_6130_run_default_services_from_simple_saved_container(self):
         """ check that we can enable services in a docker container to be run as default-services
             after it has been restarted from a commit-saved container image.

--- a/testsuite.py
+++ b/testsuite.py
@@ -20619,7 +20619,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             ## top_container2 = "docker exec {testname}x ps -eo pid,ppid,user,args"
             ## top = output(top_container2.format(**locals()))
             ## logg.info("\n>>>\n%s", top)
-            ## time.sleep(2)
+            time.sleep(2)
         #
         self.save_coverage(testname, testname+"x")
         #

--- a/testsuite.py
+++ b/testsuite.py
@@ -191,7 +191,8 @@ def systemd_escape(text):
         base_text = norm_text.encode("utf-8")
     except:
         base_text = norm_text
-    hexx_text = re.sub("([^a-zA-Z_/.])", lambda m: "\\x%02x" % ord(m.group(1)), base_text)
+    # original 'systemd-escape' encodes '@' and '.' when being the first character
+    hexx_text = re.sub("([^a-zA-Z_/@.])", lambda m: "\\x%02x" % ord(m.group(1)), base_text)
     return hexx_text.replace("/","-")
 def systemd_unescape(text):
     try:

--- a/testsuite.py
+++ b/testsuite.py
@@ -13392,7 +13392,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
              cmd = "docker exec {testname} {package} install -y {python_coverage}"
              sx____(cmd.format(**locals()))
         self.prep_coverage(testname)
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/{testscript} {testname}:{bindir}/{testscript}"
         sh____(cmd.format(**locals()))
@@ -13810,7 +13810,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -14181,7 +14181,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -14566,7 +14566,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -14908,7 +14908,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.service {testname}:{zzz_service}"
         sh____(cmd.format(**locals()))
@@ -15172,7 +15172,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.service {testname}:/etc/systemd/system/zzz.service"
         sh____(cmd.format(**locals()))
@@ -15463,7 +15463,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
              cmd = "docker exec {testname} {package} install -y {python_coverage}"
              sx____(cmd.format(**locals()))
         self.prep_coverage(testname)
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/etc/init.d/zzz"
         sh____(cmd.format(**locals()))
@@ -15788,7 +15788,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
         cmd = "docker cp {testdir}/zzz.service {testname}:{zzz_service}"
@@ -15988,7 +15988,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
              cmd = "docker exec {testname} {package} install -y {python_coverage}"
              sx____(cmd.format(**locals()))
         self.prep_coverage(testname)
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/{testscript} {testname}:{bindir}/{testscript}"
         sh____(cmd.format(**locals()))
@@ -16423,7 +16423,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -16811,7 +16811,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -17212,7 +17212,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -17570,7 +17570,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/{system}/zzz.service".format(**locals())
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.service {testname}:{zzz_service}"
         sh____(cmd.format(**locals()))
@@ -17851,7 +17851,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.service {testname}:/etc/systemd/system/zzz.service"
         sh____(cmd.format(**locals()))
@@ -18159,7 +18159,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
              cmd = "docker exec {testname} {package} install -y {python_coverage}"
              sx____(cmd.format(**locals()))
         self.prep_coverage(testname)
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/etc/init.d/zzz"
         sh____(cmd.format(**locals()))
@@ -18306,7 +18306,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
              cmd = "docker exec {testname} {package} install -y {python_coverage}"
              sx____(cmd.format(**locals()))
         self.prep_coverage(testname)
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/{testscript} {testname}:{bindir}/{testscript}"
         sh____(cmd.format(**locals()))
@@ -18520,7 +18520,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/system/zzz.service".format(**locals())
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -18743,7 +18743,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/system/zzz.service".format(**locals())
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -18970,7 +18970,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/system/zzz.service".format(**locals())
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.init {testname}:/usr/bin/zzz.init"
         sh____(cmd.format(**locals()))
@@ -19154,7 +19154,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/system/zzz.service".format(**locals())
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.service {testname}:{zzz_service}"
         sh____(cmd.format(**locals()))
@@ -19331,7 +19331,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
         zzz_service = "/etc/systemd/system/zzz.service".format(**locals())
-        cmd = "docker exec {testname} cp /usr/bin/sleep {bindir}/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" {bindir}/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zzz.service {testname}:{zzz_service}"
         sh____(cmd.format(**locals()))
@@ -19462,7 +19462,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/killall {testname}:/usr/bin/killall"
         sh____(cmd.format(**locals()))
@@ -19536,7 +19536,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
              cmd = "docker exec {testname} {package} install -y {python_coverage}"
              sx____(cmd.format(**locals()))
         self.prep_coverage(testname)
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
@@ -19634,7 +19634,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/killall {testname}:/usr/bin/killall"
         sh____(cmd.format(**locals()))
@@ -19731,7 +19731,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/killall {testname}:/usr/bin/killall"
         sh____(cmd.format(**locals()))
@@ -19816,7 +19816,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/killall {testname}:/usr/bin/killall"
         sh____(cmd.format(**locals()))
@@ -19901,7 +19901,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zza.service {testname}:/etc/systemd/system/zza.service"
         sh____(cmd.format(**locals()))
@@ -19999,7 +19999,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zza.service {testname}:/etc/systemd/system/zza.service"
         sh____(cmd.format(**locals()))
@@ -20120,7 +20120,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zza.service {testname}:/etc/systemd/system/zza.service"
         sh____(cmd.format(**locals()))
@@ -20225,7 +20225,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zza.service {testname}:/etc/systemd/system/zza.service"
         sh____(cmd.format(**locals()))
@@ -20331,7 +20331,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.prep_coverage(testname)
         cmd = "docker exec {testname} mkdir -p /etc/systemd/system /etc/systemd/user"
         sx____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testdir}/zza.service {testname}:/etc/systemd/system/zza.service"
         sh____(cmd.format(**locals()))
@@ -20443,7 +20443,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -20550,7 +20550,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -20654,7 +20654,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -20796,7 +20796,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -20943,7 +20943,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -21080,7 +21080,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -21230,7 +21230,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -21353,7 +21353,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} {refresh}"
         sh____(cmd.format(**locals()))
@@ -21509,7 +21509,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/testsleep"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/testsleep'"
         sh____(cmd.format(**locals()))
         cmd = "docker cp {testsleep_sh} {testname}:/usr/bin/testsleep.sh"
         sh____(cmd.format(**locals()))
@@ -21628,7 +21628,7 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         sx____(cmd.format(**locals()))
         cmd = "docker run --detach --name={testname} {image} sleep {sometime}"
         sh____(cmd.format(**locals()))
-        cmd = "docker exec {testname} cp /usr/bin/sleep /usr/bin/{testsleep}"
+        cmd = "docker exec {testname} bash -c 'cp \"$(command -v sleep)\" /usr/bin/{testsleep}'"
         sh____(cmd.format(**locals()))
         cmd = "docker exec {testname} touch /var/log/systemctl.debug.log"
         sh____(cmd.format(**locals()))

--- a/testsuite.py
+++ b/testsuite.py
@@ -1456,6 +1456,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.rm_testdir()
         self.rm_zzfiles(root)
         self.coverage()
+    def real_2008_list_unit_files_locations(self, real = True):
+        self.test_2008_list_unit_files_locations(real = True)
     def test_2008_list_unit_files_locations(self, real = False):
         """ check that unit files can be found for 'list-unit-files'
             in different standard locations on disk. """
@@ -1464,6 +1466,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         root = self.root(testdir, real)
         systemctl = cover() + _systemctl_py + " --root=" + root
         if real: vv, systemctl = "", "/usr/bin/systemctl"
+        self.rm_zzfiles(root)
+        #
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A
@@ -1492,8 +1496,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(out, r"zzb.service\s+disabled"))
         self.assertTrue(greps(out, r"zzc.service\s+disabled"))
         self.assertTrue(greps(out, r"zzd.service\s+disabled"))
-        self.assertIn("4 unit files listed.", out)
-        self.assertEqual(len(lines(out)), 7)
+        if not real: self.assertIn("4 unit files listed.", out)
+        if not real: self.assertEqual(len(lines(out)), 7)
         #
         cmd = "{systemctl} enable zza.service"
         out, end = output2(cmd.format(**locals()))
@@ -1520,8 +1524,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(out, r"zzb.service\s+enabled"))
         self.assertTrue(greps(out, r"zzc.service\s+enabled"))
         self.assertTrue(greps(out, r"zzd.service\s+enabled"))
-        self.assertIn("4 unit files listed.", out)
-        self.assertEqual(len(lines(out)), 7)
+        if not real: self.assertIn("4 unit files listed.", out)
+        if not real: self.assertEqual(len(lines(out)), 7)
         #
         self.rm_testdir()
         self.rm_zzfiles(root)

--- a/testsuite.py
+++ b/testsuite.py
@@ -89,8 +89,6 @@ def refresh_tool(image):
 def coverage_tool(image = None, python = None):
     image = image or IMAGE
     python = python or _python
-    # if python.endswith("3"):
-    #     return "coverage3"
     return python + " -m coverage"
 def coverage_run(image = None, python = None):
     options = " run '--omit=*/six.py,*/extern/*.py,*/unitconfparser.py' --append -- "

--- a/testsuite.py
+++ b/testsuite.py
@@ -6398,8 +6398,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
             ExecStartPost=%s B %%n $X ${Y}
             ExecStartPost=%s C %%f $X ${Y}
             ExecStartPost=%s D %%t $X ${Y}
-            ExecStartPost=%s E %%P $X ${Y}
-            ExecStartPost=%s F %%p $X ${Y}
+            ExecStartPost=%s E %%p $X ${Y}
+            ExecStartPost=%s F %%P $X ${Y}
             ExecStartPost=%s G %%I $X ${Y}
             ExecStartPost=%s H %%i $X ${Y} $FOO
             ExecStartPost=%s T %%T $X ${Y} 
@@ -6427,13 +6427,13 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertEqual(end, 0)
         log = lines(open(logfile))
         logg.info("LOG \n%s", log)
-        A="'A' 'zzb' 'zzc.service' 'x1' 'y2 y3'"  # A %%N
-        B="'B' 'zzb zzc.service' 'x1' 'y2 y3' ''" # B %%n
-        C="'C' '%s' 'x1' 'y2 y3' ''" % service_file        # C %%f
+        A="'A' 'zzb\\x20zzc' 'x1' 'y2 y3' ''"  # A %%N
+        B="'B' 'zzb\\x20zzc.service' 'x1' 'y2 y3' ''" # B %%n
+        C="'C' '/zzb zzc' 'x1' 'y2 y3' ''"        # C %%f
         D="'D' '%s' 'x1' 'y2 y3' ''" % os_path(root, RUN)  # D %%t
-        E="'E' 'zzb' 'zzc' 'x1' 'y2 y3'"  # E %%P
-        F="'F' 'zzb zzc' 'x1' 'y2 y3' ''" # F %%p
-        G="'G' 'x1' 'y2 y3' '' ''" # G %%I
+        E="'E' 'zzb\\x20zzc' 'x1' 'y2 y3' ''" # F %%p
+        F="'F' 'zzb zzc' 'x1' 'y2 y3' ''"  # E %%P
+        G="'G' '' 'x1' 'y2 y3' ''" # G %%I
         H="'H' '' 'x1' 'y2 y3' ''" # H %%i
         T="'T' '%s' 'x1' 'y2 y3' ''" % os_path(root, "/tmp")  # T %%T
         V="'V' '%s' 'x1' 'y2 y3' ''" % os_path(root, "/var/tmp")  # V %%V
@@ -6446,9 +6446,10 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertIn(F, log)
         self.assertIn(G, log)
         self.assertIn(H, log)
-        self.assertIn(T, log)
-        self.assertIn(V, log)
-        self.assertIn(Z, log)
+        if not real:
+            self.assertIn(T, log)
+            self.assertIn(V, log)
+            self.assertIn(Z, log)
         #
         self.rm_testdir()
         self.coverage()

--- a/testsuite.py
+++ b/testsuite.py
@@ -1471,21 +1471,36 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         text_file(os_path(root, "/etc/systemd/system/zza.service"),"""
             [Unit]
             Description=Testing A
+            [Service]
+            ExecStart=/usr/bin/sleep 1
             [Install]
             WantedBy=multi-user.target""")
         text_file(os_path(root, "/usr/lib/systemd/system/zzb.service"),"""
             [Unit]
             Description=Testing B
+            [Service]
+            ExecStart=/usr/bin/sleep 2
             [Install]
             WantedBy=multi-user.target""")
         text_file(os_path(root, "/lib/systemd/system/zzc.service"),"""
             [Unit]
             Description=Testing C
+            [Service]
+            ExecStart=/usr/bin/sleep 3
             [Install]
             WantedBy=multi-user.target""")
         text_file(os_path(root, "/var/run/systemd/system/zzd.service"),"""
             [Unit]
             Description=Testing D
+            [Service]
+            ExecStart=/usr/bin/sleep 4
+            [Install]
+            WantedBy=multi-user.target""")
+        text_file(os_path(root, "/var/run/systemd/system/zzz@.service"),"""
+            [Unit]
+            Description=Testing Z-%i
+            [Service]
+            ExecStart=/usr/bin/sleep 11%i
             [Install]
             WantedBy=multi-user.target""")
         cmd = "{systemctl} --type=service list-unit-files"
@@ -1496,8 +1511,9 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(out, r"zzb.service\s+disabled"))
         self.assertTrue(greps(out, r"zzc.service\s+disabled"))
         self.assertTrue(greps(out, r"zzd.service\s+disabled"))
-        if not real: self.assertIn("4 unit files listed.", out)
-        if not real: self.assertEqual(len(lines(out)), 7)
+        self.assertTrue(greps(out, r"zzz@.service\s+disabled"))
+        if not real: self.assertIn("5 unit files listed.", out)
+        if not real: self.assertEqual(len(lines(out)), 8)
         #
         cmd = "{systemctl} enable zza.service"
         out, end = output2(cmd.format(**locals()))
@@ -1524,8 +1540,8 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
         self.assertTrue(greps(out, r"zzb.service\s+enabled"))
         self.assertTrue(greps(out, r"zzc.service\s+enabled"))
         self.assertTrue(greps(out, r"zzd.service\s+enabled"))
-        if not real: self.assertIn("4 unit files listed.", out)
-        if not real: self.assertEqual(len(lines(out)), 7)
+        if not real: self.assertIn("5 unit files listed.", out)
+        if not real: self.assertEqual(len(lines(out)), 8)
         #
         self.rm_testdir()
         self.rm_zzfiles(root)


### PR DESCRIPTION
If unit is not active, reload command should fail and return -1.
This is also the behavior of original systemctl
