### PR TITLE
apply user groups in addition to "Group" defined in service definitio…

### DIFF
--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -186,11 +186,16 @@ def shutil_setuid(user = None, group = None):
         logg.debug("setgid %s '%s'", gid, group)
     if user:
         import pwd
+        import grp
         pw = pwd.getpwnam(user)
+        gid = pw.pw_gid
+        gname = grp.getgrgid(gid).gr_name
         if not group:
-            gid = pw.pw_gid
             os.setgid(gid)
             logg.debug("setgid %s", gid)
+        groups = [g.gr_gid for g in grp.getgrall() if gname in g.gr_mem]
+        os.setgroups(groups)
+        logg.debug("setgroups %s", groups)
         uid = pw.pw_uid
         os.setuid(uid)
         logg.debug("setuid %s '%s'", uid, user)

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -186,11 +186,16 @@ def shutil_setuid(user = None, group = None):
         logg.debug("setgid %s '%s'", gid, group)
     if user:
         import pwd
+        import grp
         pw = pwd.getpwnam(user)
+        gid = pw.pw_gid
+        gname = grp.getgrgid(gid).gr_name
         if not group:
-            gid = pw.pw_gid
             os.setgid(gid)
             logg.debug("setgid %s", gid)
+        groups = [g.gr_gid for g in grp.getgrall() if gname in g.gr_mem]
+        os.setgroups(groups)
+        logg.debug("setgroups %s", groups)
         uid = pw.pw_uid
         os.setuid(uid)
         logg.debug("setuid %s '%s'", uid, user)


### PR DESCRIPTION
Problem
In case the "Group" definition was present in service definition file, the user's groups were missing from the service process  leading to missing permissions.

Fix
use `os.setgroups` to set the user's group as well