### PR TITLE
fix: Use expanded User and Group during unit validation

### DIFF
--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -5145,13 +5145,13 @@ class Systemctl:
         groups = [ conf.get(section, "Group", ""), conf.get(section, "SocketGroup", "") ] + conf.getlist(section, "SupplementaryGroups")
         for user in users:
             if user:
-                try: pwd.getpwnam(user)
+                try: pwd.getpwnam(self.expand_special(user, conf))
                 except Exception as e:
                     logg.error(" %s: User does not exist: %s (%s)", unit, user, getattr(e, "__doc__", ""))
                     badusers += 1
         for group in groups:
             if group: 
-                try: grp.getgrnam(group)
+                try: grp.getgrnam(self.expand_special(group, conf))
                 except Exception as e:
                     logg.error(" %s: Group does not exist: %s (%s)", unit, group, getattr(e, "__doc__", ""))
                     badgroups += 1


### PR DESCRIPTION
My environment was using systemd templates where %i and %I were used in User and Group fields.
It failed the validation because they are passed  to pwd and grp module as non-interpolated values.

This PR addresses this issue.