### PR TITLE
Make --now option work with disable command

### DIFF
--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -22,7 +22,7 @@ import re
 from types import GeneratorType
 
 __copyright__ = "(C) 2016-2023 Guido U. Draheim, licensed under the EUPL"
-__version__ = "1.5.7106"
+__version__ = "1.5.7113"
 
 # |
 # |
@@ -5487,7 +5487,7 @@ class Systemctl:
     igno_centos = ["netconsole", "network"]
     igno_opensuse = ["raw", "pppoe", "*.local", "boot.*", "rpmconf*", "postfix*"]
     igno_ubuntu = ["mount*", "umount*", "ondemand", "*.local"]
-    igno_always = ["network*", "dbus*", "systemd-*", "kdump*"]
+    igno_always = ["network*", "dbus*", "systemd-*", "kdump*", "kmod*"]
     igno_always += ["purge-kernels.service", "after-local.service", "dm-event.*"] # as on opensuse
     igno_targets = ["remote-fs.target"]
     def _ignored_unit(self, unit, ignore_list):

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -4757,6 +4757,8 @@ class Systemctl:
         for unit in units:
             if not self.disable_unit(unit):
                 done = False
+            elif self._now:
+                self.stop_unit(unit)
         return done
     def disable_unit(self, unit):
         conf = self.load_unit_conf(unit)

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -22,7 +22,7 @@ import re
 from types import GeneratorType
 
 __copyright__ = "(C) 2016-2023 Guido U. Draheim, licensed under the EUPL"
-__version__ = "1.5.7106"
+__version__ = "1.5.7113"
 
 # |
 # |
@@ -5487,7 +5487,7 @@ class Systemctl:
     igno_centos = ["netconsole", "network"]
     igno_opensuse = ["raw", "pppoe", "*.local", "boot.*", "rpmconf*", "postfix*"]
     igno_ubuntu = ["mount*", "umount*", "ondemand", "*.local"]
-    igno_always = ["network*", "dbus*", "systemd-*", "kdump*"]
+    igno_always = ["network*", "dbus*", "systemd-*", "kdump*", "kmod*"]
     igno_always += ["purge-kernels.service", "after-local.service", "dm-event.*"] # as on opensuse
     igno_targets = ["remote-fs.target"]
     def _ignored_unit(self, unit, ignore_list):

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -4757,6 +4757,8 @@ class Systemctl:
         for unit in units:
             if not self.disable_unit(unit):
                 done = False
+            elif self._now:
+                self.stop_unit(unit)
         return done
     def disable_unit(self, unit):
         conf = self.load_unit_conf(unit)


### PR DESCRIPTION
`disable --now` should also stop services in addition to disabling them. This was already implemented for enable, I've just copied the same logic here.

`systemctl --help `confirms this is how it should work:
```
 ...
      --now               Start or stop unit after enabling or disabling it
 ...
```