### PR TITLE
feat: do not fail for option `--no-warn`

### DIFF
--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -6697,6 +6697,8 @@ if __name__ == "__main__":
                   help="Print unit dependencies as a list instead of a tree (ignored)")
     _o.add_option("--no-pager", action="store_true",
                   help="Do not pipe output into pager (mostly ignored)")
+    _o.add_option("--no-warn", action="store_true",
+                  help="Do not generate certain warnings (ignored)")
     #
     _o.add_option("-c", "--config", metavar="NAME=VAL", action="append", default=[],
                   help="..override internal variables (InitLoopSleep,SysInitTarget) {%default}")


### PR DESCRIPTION
The real `systemctl` command has an option called `--no-warn`, which is not supported yet. To simply support this option, add it without adding any further logic. So this option is simply ignored.

Ref.:
- https://www.freedesktop.org/software/systemd/man/systemctl.html
- https://gitlab.com/redhat/centos-stream/rpms/systemd/-/blob/c9s/0167-systemctl-allow-suppress-the-warning-of-no-install-i.patch