### PR TITLE
fix: use usr/bin/env to locate interpreter

### DIFF
--- a/files/docker/journalctl3.py
+++ b/files/docker/journalctl3.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python2
+#!/usr/bin/env python2
 # generated from systemctl3.py - do not change
 from __future__ import print_function
 import threading

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/env python3
 # type hints are provided in 'types/systemctl3.pyi'
 from __future__ import print_function
 import threading


### PR DESCRIPTION
Inside python:3.10-slim, the path to python3 is at `/usr/local/bin/python3`

Which causes the running of the systemctl replacement in this (and maybe other docker containers fail) 

trying to launch via bash (command prompt)
```
root@8fa696f7b7a2:/build# /usr/bin/systemctl 
bash: /usr/bin/systemctl: cannot execute: required file not found

```

This is it working, specifying the python3 interpreter directly. 
```
root@8fa696f7b7a2:/build# which python3
/usr/local/bin/python3

root@8fa696f7b7a2:/build# python3 /usr/bin/systemctl 
apt-daily-upgrade.service       loaded inactive dead    Daily apt upgrade and clean activities
apt-daily-upgrade.timer loaded unknown dead     Daily apt upgrade and clean activities
apt-daily.service       loaded inactive dead    Daily apt download activities
apt-daily.timer loaded unknown dead     Daily apt download activities
dpkg-db-backup.service  loaded inactive dead    Daily dpkg database backup service
dpkg-db-backup.timer    loaded unknown dead     Daily dpkg database backup timer
e2scrub@.service        loaded inactive dead    Online ext4 Metadata Check for 
e2scrub_all.service     loaded inactive dead    Online ext4 Metadata Check for All Filesystems
e2scrub_all.timer       loaded unknown dead     Periodic ext4 Online Metadata Check for All Filesystems
e2scrub_fail@.service   loaded inactive dead    Online ext4 Metadata Check Failure Reporting for 
e2scrub_reap.service    loaded inactive dead    Remove Stale Online ext4 Metadata Check Snapshots
fstrim.service  loaded inactive dead    Discard unused blocks on filesystems from /etc/fstab
fstrim.timer    loaded unknown dead     Discard unused blocks once a week
hwclock.sh.service      loaded inactive dead
pam_namespace.service   loaded inactive dead    Make sure parent directories configured in /etc/security/namespace.conf for polyinstantiation exist
```
[This is due to this issue ](https://github.com/docker-library/python/issues/671)

