### PR TITLE
Don't cap RestartSec at DefaultStartLimitIntervalSec

### DIFF
--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -5961,7 +5961,7 @@ class Systemctl:
         interval = conf.get(Service, "StartLimitIntervalSec", strE(defaults)) # 10s
         return time_to_seconds(interval, maximum)
     def get_RestartSec(self, conf, maximum = None):
-        maximum = maximum or DefaultStartLimitIntervalSec
+        maximum = maximum or 999
         delay = conf.get(Service, "RestartSec", strE(DefaultRestartSec))
         return time_to_seconds(delay, maximum)
     def restart_failed_units(self, units, maximum = None):

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -5961,7 +5961,7 @@ class Systemctl:
         interval = conf.get(Service, "StartLimitIntervalSec", strE(defaults)) # 10s
         return time_to_seconds(interval, maximum)
     def get_RestartSec(self, conf, maximum = None):
-        maximum = maximum or DefaultStartLimitIntervalSec
+        maximum = maximum or 999
         delay = conf.get(Service, "RestartSec", strE(DefaultRestartSec))
         return time_to_seconds(delay, maximum)
     def restart_failed_units(self, units, maximum = None):


### PR DESCRIPTION
The code currently caps `RestartSec` at `DefaultStartLimitIntervalSec`, which I'm not sure makes a lot of sense, and isn't compatible with systemd. It may originally have been a copy/paste error?

My use case is a whole-system appliance which I dockerized. It relies on `RestartSec=120` to run a job every two minutes; under docker-systemctl-replacement it runs every 10 seconds or less.