### PR TITLE
fix parsing of backslash at end of line

### DIFF
--- a/files/docker/systemctl.py
+++ b/files/docker/systemctl.py
@@ -810,6 +810,8 @@ class SystemctlConfigParser(SystemctlConfData):
             else:
                 # hint: an empty line shall reset the value-list
                 self.set(section, name, text and text or None)
+        if nextline:
+            self.set(section, name, text)
         return self
     def read_sysv(self, filename):
         """ an LSB header is scanned and converted to (almost)

--- a/files/docker/systemctl3.py
+++ b/files/docker/systemctl3.py
@@ -810,6 +810,8 @@ class SystemctlConfigParser(SystemctlConfData):
             else:
                 # hint: an empty line shall reset the value-list
                 self.set(section, name, text and text or None)
+        if nextline:
+            self.set(section, name, text)
         return self
     def read_sysv(self, filename):
         """ an LSB header is scanned and converted to (almost)

--- a/testsuite.py
+++ b/testsuite.py
@@ -1383,17 +1383,27 @@ class DockerSystemctlReplacementTest(unittest.TestCase):
                 which is quite special
             [Service]
             PIDFile=/var/run/zzfoo.pid
+            ExecStart=sleep \\
+                2 \\
+
             """)
         textA = reads(os_path(root, "/etc/systemd/system/zza.service"))
         self.assertTrue(greps(textA, "Testing A"))
         self.assertTrue(greps(textA, "quite special"))
         self.assertTrue(greps(textA, "PIDFile="))
+        self.assertTrue(greps(textA, "ExecStart="))
         cmd = "{systemctl} __get_description zza.service"
         out, end = output2(cmd.format(**locals()))
         logg.info("%s => \n%s", cmd, out)
         self.assertEqual(end, 0)
         self.assertTrue(greps(out, "Testing A"))
         self.assertTrue(greps(out, "quite special"))
+        cmd = "{systemctl} command zza.service"
+        out, end = output2(cmd.format(**locals()))
+        logg.info("%s => \n%s", cmd, out)
+        self.assertEqual(end, 0)
+        self.assertEqual(len(lines(out)), 3)
+        self.assertTrue(greps(out, "sleep \\\\"))
         cmd = "{systemctl} __get_pid_file zza.service"
         out, end = output2(cmd.format(**locals()))
         logg.info("%s => \n%s", cmd, out)


### PR DESCRIPTION
If you have an option with a line ending with a backslash that's on the last line of the file, then the option isn't added to the corresponding section. I discovered this because the [k3s installer](https://get.k3s.io/) generates a unit file that looks like this:
```
[Service]
Type=notify
ExecStart=/usr/local/bin/k3s \
        server \
```

but attempting to start it generates the error `ERROR:systemctl: k3s.service: Service lacks both ExecStart and ExecStop= setting. Refusing.` because `ExecStart` wasn't being added to the `Service` section