### PR TITLE
feat: hostnamectl and localectl replacements

### DIFF
--- a/files/docker/hostnamectl3.py
+++ b/files/docker/hostnamectl3.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+import sys
+import argparse
+
+def set_hostname(args):
+    if args.static or args.pretty or args.transient:
+        try:
+            if args.static:
+                with open("/etc/hostname", "w") as hostname_file:
+                    hostname_file.write(args.hostname + "\n")
+                print(f"Static hostname set to '{args.hostname}'")
+            if args.pretty:
+                print(f"Pretty hostname set to '{args.hostname}' (not persisted in this fake script)")
+            if args.transient:
+                print(f"Transient hostname set to '{args.hostname}' (not persisted in this fake script)")
+        except PermissionError:
+            print("Error: Permission denied. Please run as root.")
+        except Exception as e:
+            print(f"Error: {e}")
+    else:
+        print("Error: No hostname specified to set.")
+
+def show_status(args):
+    try:
+        with open("/etc/hostname", "r") as hostname_file:
+            static_hostname = hostname_file.read().strip()
+        print(f"   Static hostname: {static_hostname}")
+        print(f"   Pretty hostname: (not set in this fake script)")
+        print(f"  Transient hostname: (not set in this fake script)")
+    except FileNotFoundError:
+        print("Error: /etc/hostname not found.")
+    except Exception as e:
+        print(f"Error: {e}")
+
+def main():
+    parser = argparse.ArgumentParser(description="Fake hostnamectl script")
+    parser.add_argument("--static", action="store_true", help="Set the static hostname")
+    parser.add_argument("--transient", action="store_true", help="Set the transient hostname")
+    parser.add_argument("--pretty", action="store_true", help="Set the pretty hostname")
+    parser.add_argument("command", nargs="?", choices=[
+        "status", "hostname", "set-hostname", "icon-name", "set-icon-name",
+        "chassis", "set-chassis", "deployment", "set-deployment",
+        "location", "set-location", "help"
+    ], help="Command to execute")
+    parser.add_argument("hostname", nargs="?", help="The hostname to set (if applicable)")
+
+    args = parser.parse_args()
+
+    # Map obsolete commands to modern equivalents
+    if args.command in ["set-hostname", "set-icon-name", "set-chassis", "set-deployment", "set-location"]:
+        args.command = args.command.replace("set-", "")
+    elif args.command == "hostname":
+        args.command = "set-hostname"
+
+    if args.command == "status":
+        show_status(args)
+    elif args.command == "set-hostname":
+        if args.hostname:
+            set_hostname(args)
+        else:
+            print("Error: No hostname specified to set.")
+    elif args.command in ["icon-name", "chassis", "deployment", "location"]:
+        print(f"{args.command.capitalize()} set to '{args.hostname}' (not persisted in this fake script)")
+    elif args.command == "help":
+        parser.print_help()
+    else:
+        parser.print_help()
+
+if __name__ == "__main__":
+    main()

--- a/files/docker/localectl3.py
+++ b/files/docker/localectl3.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# Simple localectl emulator using locale
+
+import sys
+import subprocess
+import re
+import os
+
+
+def show_help():
+    """Display help information and exit."""
+    print(f"Usage: {sys.argv[0]} <command> [options]")
+    print("Commands:")
+    print("  status           Show current locale settings")
+    print("  set-locale VAR=VALUE [...]")
+    print("                   Set locale variables (e.g. LANG=en_US.UTF-8)")
+    sys.exit(1)
+
+
+def run_locale_command():
+    """Run the locale command and return its output with proper indentation."""
+    try:
+        result = subprocess.run(['locale'], capture_output=True, text=True, check=True)
+        # Add indentation to each line
+        indented_output = '\n'.join(f"      {line}" for line in result.stdout.strip().split('\n'))
+        return indented_output
+    except subprocess.CalledProcessError as e:
+        print(f"Error running locale command: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def handle_status():
+    """Handle the status command."""
+    print("   System Locale:")
+    print(run_locale_command())
+
+
+def handle_set_locale(args):
+    """Handle the set-locale command."""
+    if not args:
+        print("No locale variables provided.")
+        sys.exit(1)
+    
+    # Validate and collect locale assignments
+    valid_assignments = []
+    locale_pattern = re.compile(r'^[A-Z_]+=.+$')
+    
+    for var in args:
+        if locale_pattern.match(var):
+            valid_assignments.append(var)
+        else:
+            print(f"Invalid locale assignment: {var}")
+            sys.exit(1)
+    
+    # Write to /etc/locale.conf
+    try:
+        with open('/etc/locale.conf', 'w') as f:
+            for assignment in valid_assignments:
+                f.write(f"{assignment}\n")
+    except IOError as e:
+        print(f"Error writing to /etc/locale.conf: {e}", file=sys.stderr)
+        sys.exit(1)
+    
+    print("Locale settings updated. Current settings:")
+    print(run_locale_command())
+
+
+def main():
+    """Main function to handle command line arguments and dispatch commands."""
+    if len(sys.argv) < 2:
+        show_help()
+    
+    command = sys.argv[1]
+    args = sys.argv[2:]
+    
+    if command == "status":
+        handle_status()
+    elif command == "set-locale":
+        handle_set_locale(args)
+    else:
+        show_help()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
two more utilities that depend on a systemd are localectl and hostnamectl.

since typical usage (within ansible playbooks for example) is straightforward use of the underlying utilities, we provide a python3 script to replace these.